### PR TITLE
[FEAT] Auth 기본 세팅 및 JPA 엔티티 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	runtimeOnly 'com.h2database:h2'
 	//runtimeOnly 'org.postgresql:postgresql'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/BeatUp/BackEnd/SecurityConfig.java
+++ b/src/main/java/com/BeatUp/BackEnd/SecurityConfig.java
@@ -1,0 +1,27 @@
+package com.BeatUp.BackEnd;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+        http
+                .csrf(csrf -> csrf.disable())
+                .headers(headers -> headers.frameOptions().disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/swagger-ui/**", "/api-docs/").permitAll()
+                        .requestMatchers("/h2-console/**").permitAll()
+                        .anyRequest().permitAll()
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/BeatUp/BackEnd/controller/HealthController.java
+++ b/src/main/java/com/BeatUp/BackEnd/controller/HealthController.java
@@ -1,0 +1,67 @@
+package com.BeatUp.BackEnd.controller;
+
+import com.BeatUp.BackEnd.entity.UserAccount;
+import com.BeatUp.BackEnd.entity.UserProfile;
+import com.BeatUp.BackEnd.repository.UserAccountRepository;
+import com.BeatUp.BackEnd.repository.UserProfileRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+public class HealthController {
+
+    @Autowired
+    private UserAccountRepository userAccountRepository;
+
+    @Autowired
+    private UserProfileRepository userProfileRepository;
+
+    @GetMapping("/ping")
+    public Map<String, Object> ping(){
+        return Map.of(
+                "service", "auth-service",
+                "status", "ok",
+                "timestamp", System.currentTimeMillis()
+        );
+    }
+
+    @GetMapping("test/create-user")
+    public Map<String, Object> createTestUser(){
+        // 매번 고유한 이메일 생성(중복 방지)
+        String uniqueEmail = "test_" + UUID.randomUUID().toString().substring(0, 8) + "@example.com";
+
+        // 1. 새 사용자 계정 생성
+        UserAccount account = new UserAccount("test@example.com");
+        userAccountRepository.save(account);
+
+        // 2. 해당 사용자의 프로필 생성
+        UserProfile profile = new UserProfile(account.getId());
+        profile.updateProfile("테스트유저", UserProfile.Gender.FEMALE, 20);
+        userProfileRepository.save(profile);
+
+        return Map.of(
+                "message","테스트 생성 완료",
+                "email", uniqueEmail,
+                "accountId", account.getId().toString(),
+                "profileCompleted", profile.isProfileCompleted()
+        );
+    }
+
+    @GetMapping("test/list-users")
+    public Map<String, Object> listUsers(){
+        List<UserAccount> accounts = userAccountRepository.findAll();
+        List<UserProfile> profiles = userProfileRepository.findAll();
+
+        return Map.of(
+                "accounts", accounts.size(),
+                "profiles", profiles.size(),
+                "accountList", accounts,
+                "profileList", profiles
+        );
+    }
+}

--- a/src/main/java/com/BeatUp/BackEnd/entity/UserAccount.java
+++ b/src/main/java/com/BeatUp/BackEnd/entity/UserAccount.java
@@ -1,0 +1,46 @@
+package com.BeatUp.BackEnd.entity;
+
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "user_account")
+public class UserAccount {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String provider = "LOCAL"; // 가입 방식 (LOCAL, GOOGLE, KAKAO 등)
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    protected UserAccount(){}
+
+    public UserAccount(String email){
+        this.email = email;
+    }
+
+    // Getter 메서드들(외부에서 값을 얻을 때 사용)
+    public UUID getId(){return id;}
+    public String getEmail(){return email;}
+    public String getProvider() {return provider;}
+    public LocalDateTime getCreatedAt() {return createdAt;}
+
+    // 디버깅용
+    @Override
+    public String toString(){
+        return "UserAccount{id=" + id + "email=" + email + "}";
+    }
+
+}

--- a/src/main/java/com/BeatUp/BackEnd/entity/UserProfile.java
+++ b/src/main/java/com/BeatUp/BackEnd/entity/UserProfile.java
@@ -1,0 +1,69 @@
+package com.BeatUp.BackEnd.entity;
+
+
+import jakarta.persistence.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "user_profile")
+public class UserProfile {
+
+    @Id
+    @Column(name = "user_id")
+    private UUID userId;
+
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender = Gender.UNSPECIFIED;
+
+    @Column(name = "age")
+    private Integer age;
+
+    @Column(name = "profile_completed")
+    private boolean profileCompleted = false;
+
+    // 성별 enum 정의
+    public enum Gender{
+        MALE, FEMALE, UNSPECIFIED
+    }
+
+    // 기본 생성자
+    protected UserProfile(){};
+
+    // 새 프로필 생성용 생성자
+    public UserProfile(UUID userId){
+        this.userId = userId;
+    }
+
+    // Getter 메서드들
+    public UUID getUserId(){return userId;}
+    public String getNickname(){return nickname;}
+    public Gender getGender(){return gender;}
+    public Integer getAge(){return age;}
+    public boolean isProfileCompleted(){return profileCompleted;}
+
+    // 프로필 업데이트 메서드
+    public void updateProfile(String nickname, Gender gender, Integer age){
+        this.nickname = nickname;
+        this.gender = gender;
+        this.age = age;
+
+        // 프로필 완성 여부 자동 계산
+        this.profileCompleted = isValidProfile();
+    }
+
+    // 프로필 완성 여부 확인 메서드
+    private boolean isValidProfile(){
+        return nickname != null && !nickname.trim().isEmpty()
+                && gender != Gender.UNSPECIFIED
+                && age != null;
+    }
+
+    @Override
+    public String toString(){
+        return "UserProfile{userId=" + userId + ", nickname=" + nickname +
+                ", completed=" + profileCompleted + "}";
+    }
+}

--- a/src/main/java/com/BeatUp/BackEnd/repository/UserAccountRepository.java
+++ b/src/main/java/com/BeatUp/BackEnd/repository/UserAccountRepository.java
@@ -1,0 +1,18 @@
+package com.BeatUp.BackEnd.repository;
+
+import com.BeatUp.BackEnd.entity.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface UserAccountRepository extends JpaRepository<UserAccount, UUID> {
+
+    // 이메일로 사용자 찾기 - Spring Data JPA가 메서드 이름을 보고 자동으로 쿼리 생성
+    Optional<UserAccount> findByEmail(String email);
+
+    // 이메일이 존재하는지 확인
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/BeatUp/BackEnd/repository/UserProfileRepository.java
+++ b/src/main/java/com/BeatUp/BackEnd/repository/UserProfileRepository.java
@@ -1,0 +1,13 @@
+package com.BeatUp.BackEnd.repository;
+
+import com.BeatUp.BackEnd.entity.UserProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserProfileRepository extends JpaRepository<UserProfile, UUID> {
+
+    // userId로 profile 찾기
+    Optional<UserProfile> findByUserId(UUID userId);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,18 +1,22 @@
 spring.application.name=BackEnd
 
 
-# ?????? ??
+# H2 ??????
 spring.datasource.url=jdbc:h2:mem:testdb
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
 
-# JPA ??
+# JPA? ??? ??? ????
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=true
 
-# H2 ?? ??? (???)
+# H2 ? ??
 spring.h2.console.enabled=true
 
 # ?? ??
 server.port=8080
+
+#Swagger ??
+springdoc.api-docs.path = /api-docs
+springdoc.swagger-ui.path = /swagger-ui.html


### PR DESCRIPTION
## 📋 완료된 작업

### 작업1: 프로젝트 기본 세팅 + Swagger
- H2 인메모리 DB 설정 및 웹 콘솔 활성화
- Swagger UI 설정 완료
- Security 기본 설정 (개발용)

### 작업 2: JPA 엔티티 + Repository
- UserAccount 엔티티 (id, email, provider, createdAt)
- UserProfile 엔티티 (userId, nickname, gender, age, profileCompleted)
- Repository 인터페이스 구현
- **중요 버그 수정**: @CreationTimestamp로 createdAt NULL 에러 해결

## 확인 방법

- Swagger UI: http://localhost:8080/swagger-ui.html 접속
- H2 콘솔: http://localhost:8080/h2-console

  - JDBC URL: jdbc:h2:mem:authdb
  - Username: sa, Password: (비워둠)

- API 테스트:

  - Ping: http://localhost:8080/v1/ping
  - 사용자 생성: http://localhost:8080/v1/test/create-user 
  - 목록 조회: http://localhost:8080/v1/test/list-users


## 테스트 방법

### 로컬 실행
```bash
./gradlew bootRun