### PR TITLE
[FEAT] Concert API 구현

### DIFF
--- a/src/main/java/com/BeatUp/BackEnd/config/ConcertDataLoader.java
+++ b/src/main/java/com/BeatUp/BackEnd/config/ConcertDataLoader.java
@@ -1,0 +1,67 @@
+package com.BeatUp.BackEnd.config;
+
+
+import com.BeatUp.BackEnd.entity.Concert;
+import com.BeatUp.BackEnd.repository.ConcertRepository;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.LocalDateTime;
+
+@Configuration
+public class ConcertDataLoader {
+
+    @Bean
+    ApplicationRunner loadConcertData(ConcertRepository concertRepository){
+        return args -> {
+            // 이미 데이터가 있으면 추가하지 않음
+            if(concertRepository.count()  > 0){
+                return;
+            }
+
+            // 시드 데이터 5개 추가
+            concertRepository.save(new Concert(
+                    "New Jeans FANCON 'Bunnies Camp'",
+                    "고척 스카이돔",
+                    LocalDateTime.of(2025, 8, 3, 18, 0),
+                    "K-POP",
+                    "77000원"
+            ));
+
+            concertRepository.save(new Concert(
+                    "SEVENTEEN WORLD TOUR",
+                    "인천 인스파이어 아레나",
+                    LocalDateTime.of(2025, 9, 10, 19, 0),
+                    "K-POP",
+                    "132000원"
+            ));
+
+            concertRepository.save(new Concert(
+                    "IU CONCERT 'The Golden Hour'",
+                    "서울 올림픽체조경기장",
+                    LocalDateTime.of(2025, 10, 1, 18, 30),
+                    "K-POP",
+                    "99000원"
+            ));
+
+            concertRepository.save(new Concert(
+                    "뮤지컬 레미제라블",
+                    "충무아트센터 대극장",
+                    LocalDateTime.of(2025, 8, 15, 20, 0),
+                    "뮤지컬",
+                    "140000원"
+            ));
+
+            concertRepository.save(new Concert(
+                    "BLACKPINK WORLD TOUR 'BORN PINK'",
+                    "고양종합운동장 주경기장",
+                    LocalDateTime.of(2025, 8, 17, 18, 0),
+                    "K-POP",
+                    "154000원"
+            ));
+
+            System.out.println("Concert 시드 데이터" + concertRepository.count() + "개 로딩 완료!");
+        };
+    }
+}

--- a/src/main/java/com/BeatUp/BackEnd/config/SecurityConfig.java
+++ b/src/main/java/com/BeatUp/BackEnd/config/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers("/ping", "/test/**").permitAll()
                         .requestMatchers("/auth/login").permitAll()
+                        .requestMatchers("/concert/concerts/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/BeatUp/BackEnd/controller/ConcertController.java
+++ b/src/main/java/com/BeatUp/BackEnd/controller/ConcertController.java
@@ -1,0 +1,44 @@
+package com.BeatUp.BackEnd.controller;
+
+
+import com.BeatUp.BackEnd.entity.Concert;
+import com.BeatUp.BackEnd.service.ConcertService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/concert")
+public class ConcertController {
+
+    @Autowired
+    private ConcertService concertService;
+
+    @GetMapping("/concerts")
+    public Map<String, Object> getConcerts(
+            @RequestParam(required = false) String query,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)LocalDate date){
+
+        List<Concert> concerts = concertService.getConcerts(query, date);
+
+        return Map.of(
+                "concerts", concerts,
+                "total", concerts.size(),
+                "query", query != null ? query: "",
+                "date", date != null ? date.toString() : ""
+        );
+    }
+
+    @GetMapping("/concerts/{id}")
+    public ResponseEntity<Concert> getConcertById(@PathVariable UUID id){
+        return concertService.getConcertById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/BeatUp/BackEnd/entity/Concert.java
+++ b/src/main/java/com/BeatUp/BackEnd/entity/Concert.java
@@ -1,0 +1,53 @@
+package com.BeatUp.BackEnd.entity;
+
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "concert")
+public class Concert {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String venue;
+
+    @Column(name = "start_at")
+    private LocalDateTime startAt;
+
+    private String genre; // "K-POP", "뮤지컬", "콘서트" 등
+
+    private String price; // "77000원" 형태
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    // 생성자
+    protected Concert(){}
+
+    public Concert(String name, String venue, LocalDateTime startAt, String genre, String price){
+        this.name = name;
+        this.venue = venue;
+        this.startAt = startAt;
+        this.genre = genre;
+        this.price = price;
+    }
+
+    // Getters
+    public UUID getId(){return id;}
+    public String getName(){return name;}
+    public String getVenue(){return venue;}
+    public LocalDateTime getStartAt(){return startAt;}
+    public String getGenre(){return genre;}
+    public String getPrice(){return price;}
+    public LocalDateTime getCreatedAt(){return createdAt;}
+}

--- a/src/main/java/com/BeatUp/BackEnd/repository/ConcertRepository.java
+++ b/src/main/java/com/BeatUp/BackEnd/repository/ConcertRepository.java
@@ -1,0 +1,28 @@
+package com.BeatUp.BackEnd.repository;
+
+import com.BeatUp.BackEnd.entity.Concert;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface ConcertRepository extends JpaRepository<Concert, UUID> {
+
+    // 이름 또는 장소로 검색
+    @Query("SELECT c FROM Concert c WHERE " +
+            "(:query IS NULL OR :query = '' OR " +
+            "LOWER(c.name) LIKE LOWER(CONCAT('%', :query, '%')) OR " +
+            "LOWER(c.venue) LIKE LOWER(CONCAT('%', :query, '%'))) AND " +
+            "(:startOfDay IS NULL OR (c.startAt >= :startOfDay AND c.startAt <= :endOfDay)) " +
+            "ORDER BY c.startAt ASC")
+    List<Concert> findByQueryAndDate(
+            @Param("query") String query,
+            @Param("startOfDay")LocalDateTime startOfDay,
+            @Param("endOfDay") LocalDateTime endOfDay);
+}

--- a/src/main/java/com/BeatUp/BackEnd/service/ConcertService.java
+++ b/src/main/java/com/BeatUp/BackEnd/service/ConcertService.java
@@ -1,0 +1,42 @@
+package com.BeatUp.BackEnd.service;
+
+
+import com.BeatUp.BackEnd.entity.Concert;
+import com.BeatUp.BackEnd.repository.ConcertRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.swing.text.html.Option;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class ConcertService {
+
+    @Autowired
+    private ConcertRepository concertRepository;
+
+    // 공연 목록 조회(검색 + 날짜 필터)
+    public List<Concert> getConcerts(String query, LocalDate date){
+        LocalDateTime startOfDay = null;
+        LocalDateTime endOfDay = null;
+
+        // LocalDate를 LocalDateTime 범위로 변환
+        if(date != null)
+        {
+            startOfDay = date.atStartOfDay(); // 해당 날짜의 00:00:00
+            endOfDay = date.atTime(LocalTime.MAX); // 해당 날짜의 23:59:59.9999
+        }
+
+        return concertRepository.findByQueryAndDate(query, startOfDay, endOfDay);
+    }
+
+    // 공연 상세 조회
+    public Optional<Concert> getConcertById(UUID id){
+        return concertRepository.findById(id);
+    }
+}


### PR DESCRIPTION
## 📋 완료된 작업

### ✅  Concert API - 시드 데이터로 MVP
- **목표**: 홈/검색에서 공연을 고르고, concertId를 매칭/커뮤니티에 사용
- **실제 공연 데이터**: NewJeans, SEVENTEEN, IU, 레미제라블, BLACKPINK 등 5개
- **자동 데이터 로딩**: 애플리케이션 시작 시 시드 데이터 자동 생성
- **공개 API**: 인증 없이 누구나 조회 가능

## 🎯 주요 기능

### API 엔드포인트
| Method | Endpoint | 파라미터 | 설명 |
|--------|----------|----------|------|
| GET | `/concert/v1/concerts` | query, date | 공연 목록 (검색/필터) |
| GET | `/concert/v1/concerts/{id}` | - | 공연 상세 정보 |

### 검색 및 필터링
- **텍스트 검색**: 공연명 또는 공연장명으로 부분 일치 검색
- **날짜 필터**: 특정 날짜의 공연만 조회 (YYYY-MM-DD 형식)
- **정렬**: 공연 시작일 오름차순

## 🔧 기술적 해결사항
- **H2 호환성**: `DATE()` 함수 대신 LocalDateTime 범위 비교 사용
- **자동 데이터 로딩**: ApplicationRunner로 시드 데이터 중복 방지
- **검색 최적화**: LOWER() + LIKE로 대소문자 무시 검색

## 🧪 테스트 방법

### Swagger UI 테스트
1. **애플리케이션 실행**: `./gradlew bootRun`
2. **Swagger 접속**: http://localhost:8080/swagger-ui.html
3. **공연 목록**: `GET /concert/v1/concerts` → 5개 공연 확인
4. **검색 테스트**: query="NewJeans" → 1개 결과
5. **날짜 필터**: date="2025-08-03" → 해당 날짜 공연만
6. **상세 조회**: 목록에서 id 복사 → 상세 API 호출

## 결과 화면
- **DB 목록**
<img width="2620" height="1100" alt="image" src="https://github.com/user-attachments/assets/1c159349-35c6-40fa-800b-22f28e1c6939" />



- **Swagger 화면**
<img width="1620" height="1336" alt="image" src="https://github.com/user-attachments/assets/230de8b9-5f79-4b09-b6ba-51d7e614dc1d" />
<img width="1370" height="884" alt="image" src="https://github.com/user-attachments/assets/099dd729-cf5f-488b-823c-daa06e3c4b77" />
<img width="3100" height="1708" alt="image" src="https://github.com/user-attachments/assets/1e13758f-52ea-47a6-87e2-fc35ec2e5b0d" />



### curl 테스트 예시
```bash
# 전체 목록
curl http://localhost:8080/concert/v1/concerts

# 검색
curl "http://localhost:8080/concert/v1/concerts?query=NewJeans"

# 날짜 필터
curl "http://localhost:8080/concert/v1/concerts?date=2025-08-03"