### PR TITLE
[feat]: ConcertSyncService 구현 및 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,8 @@ repositories {
 	mavenCentral()
 }
 
+
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -62,6 +64,13 @@ dependencies {
 
     // JSON/XML 파싱 지원
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+    // JAXB 지원
+    implementation 'jakarta.xml.bind:jakarta.xml.bind-api'
+    implementation 'org.glassfish.jaxb:jaxb-runtime'
 
     // 캐싱
     implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/src/main/java/com/BeatUp/BackEnd/Admin/controller/ConcertSyncController.java
+++ b/src/main/java/com/BeatUp/BackEnd/Admin/controller/ConcertSyncController.java
@@ -1,0 +1,72 @@
+package com.BeatUp.BackEnd.Admin.controller;
+
+
+import com.BeatUp.BackEnd.Concert.service.ConcertSyncService;
+import com.BeatUp.BackEnd.Concert.service.sync.SyncStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/admin/")
+@RequiredArgsConstructor
+public class ConcertSyncController {
+
+    private final ConcertSyncService concertSyncService;
+
+    /**
+     * 현재 동기화 목록 조회
+     */
+    @GetMapping("/status")
+    public ResponseEntity<SyncStatus> getSyncStatus(){
+        SyncStatus status = concertSyncService.getCurrentStatus();
+        return ResponseEntity.ok(status);
+    }
+
+    /**
+     * 수동 초기 동기화 트리거
+     */
+    @PostMapping("/inital")
+    public ResponseEntity<Map<String, Object>> triggerInitialSync(){
+        int synced = concertSyncService.performInitialSync();
+        return ResponseEntity.ok(Map.of(
+                "message", "초기 동기화 완료",
+                "synced", synced
+        ));
+    }
+
+    /**
+     * 날짜 범위 지정 동기화
+     */
+    @PostMapping("/range")
+    public ResponseEntity<Map<String, Object>> syncDateRange(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)LocalDate endDate
+            ){
+
+        int synced = concertSyncService.syncDataRange(startDate, endDate);
+        return ResponseEntity.ok(Map.of(
+                "message", String.format("범위 동기화 완료: %s ~ %s", startDate, endDate),
+                "synced", synced,
+                "startDate", startDate,
+                "endDate", endDate
+        ));
+    }
+
+    /**
+     * 단일 KOPIS ID 동기화
+     */
+    @PostMapping("/single/{kopisId}")
+    public ResponseEntity<Map<String, Object>> syncSingle(@PathVariable String kopisId){
+        var concert = concertSyncService.syncByKopisId(kopisId);
+        return ResponseEntity.ok(Map.of(
+                "kopisId", kopisId,
+                "success", concert != null,
+                "concertName", concert != null ? concert.getName() : null
+        ));
+    }
+}

--- a/src/main/java/com/BeatUp/BackEnd/Admin/controller/ConcertSyncController.java
+++ b/src/main/java/com/BeatUp/BackEnd/Admin/controller/ConcertSyncController.java
@@ -48,7 +48,7 @@ public class ConcertSyncController {
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)LocalDate endDate
             ){
 
-        int synced = concertSyncService.syncDataRange(startDate, endDate);
+        int synced = concertSyncService.syncDateRange(startDate, endDate);
         return ResponseEntity.ok(Map.of(
                 "message", String.format("범위 동기화 완료: %s ~ %s", startDate, endDate),
                 "synced", synced,

--- a/src/main/java/com/BeatUp/BackEnd/Concert/client/KopisApiClient.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/client/KopisApiClient.java
@@ -8,7 +8,6 @@ import com.BeatUp.BackEnd.Concert.enums.KopisGenre;
 import com.BeatUp.BackEnd.Concert.enums.KopisPerformanceState;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cglib.core.Local;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
@@ -210,7 +209,7 @@ public class KopisApiClient {
         }
     }
 
-    public Optional<KopisPerformanceDto> getPerformanceDetails(String mt20id){
+    public Optional<KopisPerformanceDto> getPerformanceDetail(String mt20id){
         try{
             return getPerformanceDetailAsync(mt20id).block();
         } catch (Exception e) {

--- a/src/main/java/com/BeatUp/BackEnd/Concert/client/KopisApiClient.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/client/KopisApiClient.java
@@ -180,7 +180,9 @@ public class KopisApiClient {
                 })
                 .onStatus(HttpStatusCode::is5xxServerError, response ->
                         Mono.error(new KopisApiException("서버 오류")))
-                .bodyToMono(KopisApiResponse.class)
+                .bodyToMono(String.class)
+                .map(this::sanitizeXml)
+                .flatMap(this::parseXmlToResponse)
                 .map(response -> {
                     List<KopisPerformanceDto> performances = extractPerformances(response);
                     return performances.isEmpty() ?

--- a/src/main/java/com/BeatUp/BackEnd/Concert/client/KopisApiClient.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/client/KopisApiClient.java
@@ -6,6 +6,7 @@ import com.BeatUp.BackEnd.Concert.dto.response.KopisApiResponse;
 import com.BeatUp.BackEnd.Concert.dto.response.KopisPerformanceDto;
 import com.BeatUp.BackEnd.Concert.enums.KopisGenre;
 import com.BeatUp.BackEnd.Concert.enums.KopisPerformanceState;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -30,6 +31,7 @@ import static java.util.Optional.empty;
 public class KopisApiClient {
 
     private final WebClient webClient;
+    private final XmlMapper xmlMapper;
     private final String serviceKey;
     private final String responseFormat;
     private final int maxRetry;
@@ -41,6 +43,7 @@ public class KopisApiClient {
     private static final int MAX_DAYS = 31;
 
     public KopisApiClient(WebClient.Builder webClientBuilder,
+                          XmlMapper xmlMapper,
                           @Value("${kopis.api.base-url}") String baseUrl,
                           @Value("${kopis.api.service-key}") String serviceKey,
                           @Value("${kopis.api.response-format:json}") String responseFormat,
@@ -51,6 +54,7 @@ public class KopisApiClient {
                 .baseUrl(baseUrl)
                 .codecs(configurer ->configurer.defaultCodecs().maxInMemorySize(2 * 1024 * 1024))
                 .build();
+        this.xmlMapper = xmlMapper;
         this.serviceKey = serviceKey;
         this.responseFormat = responseFormat;
         this.maxRetry = maxRetry;
@@ -65,11 +69,19 @@ public class KopisApiClient {
             KopisGenre genre, KopisPerformanceState state,
             String area, int page, int rows
     ){
-        // effectively final 변수로 새로 선언
-        final LocalDate effectiveEndDate = startDate.plusDays(MAX_DAYS).isBefore(endDate)
-                ? startDate.plusDays(MAX_DAYS)
+        // API 키 검증
+        if(serviceKey == null || serviceKey.trim().isEmpty()){
+            log.error("KOPIS API 서비스 키가 설정되지 않았습니다.");
+            return Mono.just(List.of());
+        }
+
+        // 31일 제한: 30일 간격이 안전
+        final LocalDate effectiveEndDate = endDate.isAfter(startDate.plusDays(30))
+                ? startDate.plusDays(30)
                 : endDate;
-        final int effectiveRows = Math.min(rows, MAX_ROWS);
+
+        // rows 제한
+        final int effectiveRows = Math.min(rows, 10);
 
         // API 제약사항 검증
         if(startDate.plusDays(MAX_DAYS).isBefore(endDate)){
@@ -92,18 +104,12 @@ public class KopisApiClient {
                             .queryParam("rows", effectiveRows)
                             .queryParam("cpage", page);
 
-
-                    // JSON 응답 요청
-                    if("json".equalsIgnoreCase(responseFormat)){
-                        builder.queryParam("_type", "json");
-                    }
-
                     // 선택적 필터 파라미터
                     if(genre != null){
                         builder.queryParam("shcate", genre.getCode());
                     }
                     if(state != null){
-                        builder.queryParam("pr=fstate", state.getCode());
+                        builder.queryParam("prfstate", state.getCode());
                     }
                     if(area != null && !area.trim().isEmpty()){
                         builder.queryParam("signgucode", area);
@@ -111,8 +117,7 @@ public class KopisApiClient {
 
                     return builder.build();
                 })
-                .accept("json".equalsIgnoreCase(responseFormat) ?
-                        MediaType.APPLICATION_JSON : MediaType.APPLICATION_XML)
+                .accept(MediaType.APPLICATION_XML, MediaType.TEXT_XML)
                 .retrieve()
                 .onStatus(HttpStatusCode::is4xxClientError, response -> {
                     log.error("KOPIS API 클라이언트 오류 - status: {}", response.statusCode());
@@ -123,13 +128,16 @@ public class KopisApiClient {
                     log.error("KOPIS API 서버 오류 - status: {}", response.statusCode());
                     return Mono.error(new KopisApiException("서버 오류"));
                 })
-                .bodyToMono(KopisApiResponse.class)
+                .bodyToMono(String.class)  // ✅ 1단계: String으로 XML 받기
+                .map(this::sanitizeXml)    // ✅ 2단계: XML 정리
+                .flatMap(this::parseXmlToResponse)  // ✅ 3단계: 수동 파싱
                 .map(this::extractPerformances)
                 .retryWhen(Retry.backoff(maxRetry, Duration.ofMillis(delayBetweenCalls))
-                .filter(this::isRetryableException)
-                .doBeforeRetry(retrySignal ->
-                        log.warn("KOPIS API 재시도: {}/{} - 오류: {}",
-                                retrySignal.totalRetries() + 1, maxRetry, retrySignal.failure().getMessage())))
+                        .filter(this::isRetryableException)
+                        .doBeforeRetry(retrySignal ->
+                                log.warn("KOPIS API 재시도 {}/{} - 오류: {}",
+                                        retrySignal.totalRetries() + 1, maxRetry,
+                                        retrySignal.failure().getMessage())))
                 .delayElement(Duration.ofMillis(delayBetweenCalls))
                 .doOnSuccess(result ->
                         log.debug("KOPIS API 공연 목록 조회 완료 - 결과 수: {}", result.size()))
@@ -216,6 +224,62 @@ public class KopisApiClient {
             log.error("동기 공연 조회 실패 - mt20id: {}", e);
             return Optional.empty();
         }
+    }
+
+    /**
+     * XML 응답 처리 (% 문자, BOM 제거 등)
+     */
+    private String sanitizeXml(String xml){
+        if(xml == null || xml.trim().isEmpty()){
+            return xml;
+        }
+
+        String sanitized = xml.strip();
+
+        // XML 응답 끝의 % 문자 제거
+        if(sanitized.endsWith("%")){
+            sanitized = sanitized.substring(0, sanitized.length() -1);
+        }
+
+        // BOM 제거
+        if(sanitized.startsWith("\uFEFF")){
+            sanitized = sanitized.substring(1);
+        }
+
+        return sanitized;
+    }
+
+
+    /**
+     * XML 문자열을 KopisApiResponse 객체로 파싱
+     */
+    private Mono<KopisApiResponse> parseXmlToResponse(String xml) {
+        return Mono.fromCallable(() -> {
+            try {
+                if (xml == null || xml.trim().isEmpty()) {
+                    log.warn("빈 XML 응답입니다");
+                    return new KopisApiResponse();
+                }
+
+                // ✅ XmlMapper로 수동 파싱
+                KopisApiResponse response = xmlMapper.readValue(xml, KopisApiResponse.class);
+
+                if (response == null) {
+                    log.warn("XML 파싱 결과가 null입니다");
+                    return new KopisApiResponse();
+                }
+
+                return response;
+
+            } catch (Exception e) {
+                log.error("XML 파싱 실패: {}", e.getMessage());
+                log.debug("파싱 실패한 XML 내용: {}",
+                        xml.length() > 500 ? xml.substring(0, 500) + "..." : xml);
+
+                // ✅ 파싱 실패 시에도 빈 응답으로 처리하여 애플리케이션 중단 방지
+                return new KopisApiResponse();
+            }
+        });
     }
 
     private List<KopisPerformanceDto> extractPerformances(KopisApiResponse response){

--- a/src/main/java/com/BeatUp/BackEnd/Concert/config/ConcertDataLoader.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/config/ConcertDataLoader.java
@@ -2,6 +2,7 @@ package com.BeatUp.BackEnd.Concert.config;
 
 import com.BeatUp.BackEnd.Concert.entity.Concert;
 import com.BeatUp.BackEnd.Concert.repository.ConcertRepository;
+import com.BeatUp.BackEnd.Concert.service.ConcertSyncService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationRunner;
@@ -16,10 +17,17 @@ import java.time.LocalDateTime;
 public class ConcertDataLoader {
 
     private final ConcertRepository concertRepository;
+    private final ConcertSyncService concertSyncService;
 
     @Bean
     ApplicationRunner loadConcertData(){
         return args -> {
+            long initialCount = concertRepository.count();
+
+            if(initialCount == 0){
+                log.info("Concert 데이터가 없어 시드 데이터 로딩 시작");
+            }
+
             // 이미 데이터가 있으면 추가하지 않음
             if(concertRepository.count()  > 0){
                 return;

--- a/src/main/java/com/BeatUp/BackEnd/Concert/config/KopisApiConfig.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/config/KopisApiConfig.java
@@ -1,0 +1,75 @@
+package com.BeatUp.BackEnd.Concert.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class KopisApiConfig {
+
+    @Value("${kopis.api.timeout:30000}")
+    private int timeout;
+
+    /**
+     * JSON 응답 직렬화용 ObjectMapper 설정
+     */
+    @Bean
+    public ObjectMapper objectMapper(){
+        ObjectMapper mapper = new ObjectMapper();
+
+        // 날짜/시간 지원
+        mapper.registerModule(new JavaTimeModule());
+
+        // ISO-8601로 직렬화
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // 알려지지 않은 속성 무시
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        return mapper;
+    }
+
+    @Bean
+    public XmlMapper xmlMapper() {
+        XmlMapper mapper = new XmlMapper();
+        // KOPIS XML 응답에 최적화된 설정
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        mapper.configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true);
+        mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
+        return mapper;
+    }
+
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, timeout)
+                .responseTimeout(Duration.ofMillis(timeout))
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler(timeout, TimeUnit.MILLISECONDS))
+                        .addHandlerLast(new WriteTimeoutHandler(timeout, TimeUnit.MILLISECONDS)));
+
+        // 복잡한 코덱 설정 없이 기본 설정만 사용
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .defaultHeader(HttpHeaders.USER_AGENT, "BeatUp-Concert-Service/1.0")
+                .codecs(configurer ->
+                        configurer.defaultCodecs().maxInMemorySize(2 * 1024 * 1024));
+    }
+}

--- a/src/main/java/com/BeatUp/BackEnd/Concert/config/KopisSmokeTestRunner.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/config/KopisSmokeTestRunner.java
@@ -39,7 +39,7 @@ public class KopisSmokeTestRunner {
                     var first = performances.get(0);
                     log.info("샘플 뮤지컬: {} (ID: {},  장소: {})", first.getPrfnm(), first.getMt20id(), first.getFcltynm());
 
-                    var detail = kopisApiClient.getPerformanceDetails(first.getMt20id());
+                    var detail = kopisApiClient.getPerformanceDetail(first.getMt20id());
                     if(detail.isPresent()){
                         log.info("상세 조회 성공 - 출연진: {}, 런타임: {}", detail.get().getPrfcast(), detail.get().getPrfruntime());
                     }

--- a/src/main/java/com/BeatUp/BackEnd/Concert/controller/ConcertController.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/controller/ConcertController.java
@@ -5,11 +5,14 @@ import com.BeatUp.BackEnd.Concert.dto.ConcertSearchCondition;
 import com.BeatUp.BackEnd.Concert.entity.Concert;
 import com.BeatUp.BackEnd.Concert.enums.DataSource;
 import com.BeatUp.BackEnd.Concert.service.ConcertService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,14 +22,14 @@ import java.util.Map;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/concert")
+@RequestMapping(value = "/concert", produces = MediaType.APPLICATION_JSON_VALUE)
 @RequiredArgsConstructor
 public class ConcertController {
 
     @Autowired
     private ConcertService concertService;
 
-    @GetMapping("/concerts")
+    @GetMapping(value = "/concerts", produces = MediaType.APPLICATION_JSON_VALUE)
     public Map<String, Object> getConcerts(
             @RequestParam(required = false) String query,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)LocalDate date){

--- a/src/main/java/com/BeatUp/BackEnd/Concert/dto/ConcertSearchCondition.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/dto/ConcertSearchCondition.java
@@ -11,7 +11,7 @@ import java.time.LocalDate;
 @Builder
 public class ConcertSearchCondition {
     private String query; // 통합 검색어 (이름, 장소, 출연진)
-    private LocalDate date; // 특정 날짜
+    private LocalDate date;// 특정 날짜
     private LocalDate startDate; // 시작 날짜 범위
     private LocalDate endDate; // 종료 날짜 범위
     private String genre; // 장르

--- a/src/main/java/com/BeatUp/BackEnd/Concert/dto/response/KopisApiResponse.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/dto/response/KopisApiResponse.java
@@ -3,6 +3,9 @@ package com.BeatUp.BackEnd.Concert.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import lombok.*;
 
 import java.util.List;
@@ -13,19 +16,23 @@ import java.util.List;
 @AllArgsConstructor
 @ToString
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JacksonXmlRootElement(localName = "dbs")
 public class KopisApiResponse {
 
     @JsonProperty("dbs")
-    private KopisDbs dbs;
+    @JacksonXmlProperty(localName = "db")
+    @JacksonXmlElementWrapper(useWrapping = false)
+    private List<KopisPerformanceDto> db;
+
+    public KopisDbs getDbs(){
+        return new KopisDbs(db);
+    }
 
     @Getter
     @Setter
     @NoArgsConstructor
     @AllArgsConstructor
-    @ToString
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class KopisDbs{
-        @JsonProperty("db")
         private List<KopisPerformanceDto> db;
     }
 }

--- a/src/main/java/com/BeatUp/BackEnd/Concert/dto/response/KopisPerformanceDto.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/dto/response/KopisPerformanceDto.java
@@ -5,6 +5,7 @@ import com.BeatUp.BackEnd.Concert.enums.KopisGenre;
 import com.BeatUp.BackEnd.Concert.enums.KopisPerformanceState;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
@@ -22,35 +23,45 @@ public class KopisPerformanceDto {
 
     // 공연 목록/상세 공통 필드
     @JsonProperty("mt20id")
+    @JacksonXmlProperty(localName = "mt20id")
     @NotBlank
     private String mt20id;          // 공연ID
 
     @JsonProperty("prfnm")
+    @JacksonXmlProperty(localName = "prfnm")
     private String prfnm;           // 공연명
 
     @JsonProperty("prfpdfrom")
+    @JacksonXmlProperty(localName = "prfpdfrom")
     private String prfpdfrom;       // 공연시작일 (yyyy.MM.dd)
 
     @JsonProperty("prfpdto")
+    @JacksonXmlProperty(localName = "prfpdto")
     private String prfpdto;         // 공연종료일 (yyyy.MM.dd)
 
     @JsonProperty("fcltynm")
+    @JacksonXmlProperty(localName = "fcltynm")
     private String fcltynm;         // 공연시설명(공연장명)
 
     @JsonProperty("poster")
-    private String poster;          // 공연포스터경로
+    @JacksonXmlProperty(localName = "poster")
+    private String poster; // 공연포스터경로
 
     @JsonProperty("genrenm")
+    @JacksonXmlProperty(localName = "genrenm")
     private String genrenm;         // 공연장르명
 
     @JsonProperty("prfstate")
+    @JacksonXmlProperty(localName = "prfstate")
     private String prfstate;        // 공연상태
 
     // 목록 조회 추가 필드
     @JsonProperty("area")
+    @JacksonXmlProperty(localName = "area")
     private String area;            // 공연지역
 
     @JsonProperty("openrun")
+    @JacksonXmlProperty(localName = "openrun")
     private String openrun;         // 오픈런 (Y/N)
 
     // 상세 조회 전용 필드
@@ -58,15 +69,18 @@ public class KopisPerformanceDto {
     private String mt10id;          // 공연시설ID
 
     @JsonProperty("prfcast")
+    @JacksonXmlProperty(localName = "prfcast")
     private String prfcast;         // 공연출연진
 
     @JsonProperty("prfcrew")
     private String prfcrew;         // 공연제작진
 
     @JsonProperty("prfruntime")
+    @JacksonXmlProperty(localName = "prfruntime")
     private String prfruntime;      // 공연런타임
 
     @JsonProperty("prfage")
+    @JacksonXmlProperty(localName = "prfage")
     private String prfage;          // 공연관람연령
 
     @JsonProperty("entrpsnmP")
@@ -82,6 +96,7 @@ public class KopisPerformanceDto {
     private String entrpsnmS;       // 주관
 
     @JsonProperty("pcseguidance")
+    @JacksonXmlProperty(localName = "pcseguidance")
     private String pcseguidance;    // 티켓가격
 
     @JsonProperty("sty")

--- a/src/main/java/com/BeatUp/BackEnd/Concert/entity/Concert.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/entity/Concert.java
@@ -7,6 +7,7 @@ import com.BeatUp.BackEnd.Concert.initializer.ConcertInitializer;
 import com.BeatUp.BackEnd.Concert.logic.ConcertBusinessLogic;
 import com.BeatUp.BackEnd.Concert.mapper.ConcertKopisMapper;
 import com.BeatUp.BackEnd.common.entity.BaseEntity;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -26,6 +27,7 @@ public class Concert extends BaseEntity {
     @Column(length = 200)
     private String venue;
 
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     @Column(name = "start_at")
     private LocalDateTime startAt;
 
@@ -117,9 +119,11 @@ public class Concert extends BaseEntity {
     private Boolean isVisit = false;
 
     // 동기화 정보
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     @Column(name = "last_synced_at")
     private LocalDateTime lastSyncedAt;
 
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     @Column(name = "kopis_updated_at")
     private LocalDateTime kopisUpdatedAt;
 
@@ -155,6 +159,7 @@ public class Concert extends BaseEntity {
         return ConcertBusinessLogic.isOngoing(this);
     }
 
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     public LocalDateTime getStartAt(){
         return startDate != null ? startDate.atStartOfDay() : startAt;
     }

--- a/src/main/java/com/BeatUp/BackEnd/Concert/repository/ConcertRepository.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/repository/ConcertRepository.java
@@ -30,7 +30,8 @@ public interface ConcertRepository extends JpaRepository<Concert, UUID>, Concert
             "(:query IS NULL OR :query = '' OR " +
             "LOWER(c.name) LIKE LOWER(CONCAT('%', :query, '%')) OR " +
             "LOWER(c.venue) LIKE LOWER(CONCAT('%', :query, '%'))) AND " +
-            "(:date IS NULL OR (c.startDate >= :date AND (c.endDate IS NULL OR c.endDate >= :date))) " +
+            "(c.startDate >= COALESCE(:date, c.startDate) AND " +
+            " (c.endDate IS NULL OR c.endDate >= COALESCE(:date, c.endDate))) " +
             "ORDER BY c.startDate ASC")
     List<Concert> findByQueryAndDate(
             @Param("query") String query,

--- a/src/main/java/com/BeatUp/BackEnd/Concert/service/ConcertSyncService.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/service/ConcertSyncService.java
@@ -1,0 +1,163 @@
+package com.BeatUp.BackEnd.Concert.service;
+
+
+
+import com.BeatUp.BackEnd.Concert.entity.Concert;
+import com.BeatUp.BackEnd.Concert.service.sync.ConcertSyncExecutor;
+import com.BeatUp.BackEnd.Concert.service.sync.SyncStatus;
+import com.BeatUp.BackEnd.Concert.service.sync.SyncStatusProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ConcertSyncService {
+
+    private final ConcertSyncExecutor syncExecutor;
+    private final SyncStatusProvider statusProvider;
+    private final AtomicInteger syncInProgress = new AtomicInteger(0);
+
+    /**
+     * 매일 새벽 2시 전체 동기화 실행
+     */
+    @Scheduled(cron = "0 0 2 * * ?")
+    @Async("concertSyncExecutor")
+    public void scheduledFullSync(){
+        if(syncInProgress.get() > 0){
+            log.warn("이미 동기화가 진행 중입니다. 건너뜁니다.");
+            return;
+        }
+
+        log.info("KOPIS 전체 데이터 동기화 시작");
+
+        try{
+            syncInProgress.incrementAndGet();
+
+            LocalDate startDate = LocalDate.now().minusMonths(1); // 과거 1개월
+            LocalDate endDate = LocalDate.now().plusMonths(6); // 미래 6개월
+
+            int totalSynced = syncExecutor.syncDateRange(startDate, endDate);
+
+            log.info("KOPIS 전체 동기화 완료 - {}개 처리", totalSynced);
+        } catch (Exception e) {
+            log.error("전체 동기화 중 오류 발생", e);
+        } finally {
+            syncInProgress.decrementAndGet();
+        }
+    }
+
+    /**
+     * 매시간 증분 동기화 (최근 변경 데이터만)
+     */
+    @Scheduled(fixedRate = 36000000)
+    @Async("concertSyncExecutor")
+    public void scheduledIncrementalSync(){
+        if(syncInProgress.get() > 0){
+            return;
+        }
+
+        log.error("KOPIS 증분 동기화 시작");
+
+        try{
+            syncInProgress.incrementAndGet();
+
+            // 1) 동기화 필요한 기존 데이터 업데이트
+            int updatedCount = syncExecutor.refreshExistingConcerts();
+
+            // 2) 최근 1주일 신규 데이터 확인
+            LocalDate recentStart = LocalDate.now().minusDays(7);
+            LocalDate recentEnd = LocalDate.now().plusWeeks(2);
+            int newCount = syncExecutor.syncDateRange(recentStart, recentEnd);
+
+            if(updatedCount > 0 || newCount > 0){
+                log.info("KOPIS 증분 동기화 완료 - 업데이트: {}개, 신규: {}개", updatedCount, newCount);
+            }
+        }catch (Exception e){
+            log.error("증분 동기화 중 오류 발생", e);
+        }finally {
+            syncInProgress.decrementAndGet();
+        }
+    }
+
+    /**
+     * 수동 초기 동기화 트리거
+     */
+    public int performInitialSync(){
+        if(!tryStartSync()){
+            log.warn("이미 동기화가 진행 중입니다.");
+            return 0;
+        }
+
+        log.info("KOPIS 초기 동기화 시작");
+
+        try{
+            LocalDate today = LocalDate.now();
+            LocalDate syncStart = today;
+            LocalDate syncEnd = today.plusMonths(3); // 향후 3개월
+
+            int synced = syncExecutor.syncDateRange(syncStart, syncEnd);
+            log.info("KOPIS 초기 동기화 완료 - {}개 처리", synced);
+
+            return synced;
+        }finally {
+            finishSync();
+        }
+    }
+
+    /**
+     * 특정 날짜 범위 동기화
+     */
+    public int syncDataRange(LocalDate startDate, LocalDate endDate){
+        if(!tryStartSync()){
+            log.warn("이미 동기화가 진행 중입니다.");
+            return 0;
+        }
+
+        try{
+            return syncExecutor.syncDateRange(startDate, endDate);
+        }finally {
+            finishSync();
+        }
+    }
+
+    /**
+     * 단일 KOPIS ID 동기화 (Fallback 용)
+     */
+    public Concert syncByKopisId(String kopisId){
+        return syncExecutor.syncSingleKopisId(kopisId);
+    }
+
+    /**
+     * 현재 동기화 상태 조회
+     */
+    public SyncStatus getCurrentStatus(){
+        return statusProvider.getCurrentStatus(syncInProgress.get() > 0);
+    }
+
+    // 동기화 상태 관리
+    private boolean tryStartSync(){
+        return syncInProgress.compareAndSet(0, 1);
+    }
+
+    private void finishSync(){
+        syncInProgress.set(0);
+    }
+
+
+
+
+
+
+
+
+
+
+
+}

--- a/src/main/java/com/BeatUp/BackEnd/Concert/service/ConcertSyncService.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/service/ConcertSyncService.java
@@ -28,9 +28,9 @@ public class ConcertSyncService {
      * 매일 새벽 2시 전체 동기화 실행
      */
     @Scheduled(cron = "0 0 2 * * ?")
-    @Async("concertSyncExecutor")
+    @Async("concertSyncTaskExecutor")
     public void scheduledFullSync(){
-        if(syncInProgress.get() > 0){
+        if(!tryStartSync()){
             log.warn("이미 동기화가 진행 중입니다. 건너뜁니다.");
             return;
         }
@@ -56,14 +56,14 @@ public class ConcertSyncService {
     /**
      * 매시간 증분 동기화 (최근 변경 데이터만)
      */
-    @Scheduled(fixedRate = 36000000)
-    @Async("concertSyncExecutor")
+    @Scheduled(fixedRate = 3600000)
+    @Async("concertSyncTaskExecutor")
     public void scheduledIncrementalSync(){
         if(syncInProgress.get() > 0){
             return;
         }
 
-        log.error("KOPIS 증분 동기화 시작");
+        log.debug("KOPIS 증분 동기화 시작");
 
         try{
             syncInProgress.incrementAndGet();
@@ -114,7 +114,7 @@ public class ConcertSyncService {
     /**
      * 특정 날짜 범위 동기화
      */
-    public int syncDataRange(LocalDate startDate, LocalDate endDate){
+    public int syncDateRange(LocalDate startDate, LocalDate endDate){
         if(!tryStartSync()){
             log.warn("이미 동기화가 진행 중입니다.");
             return 0;

--- a/src/main/java/com/BeatUp/BackEnd/Concert/service/ConcertSyncService.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/service/ConcertSyncService.java
@@ -38,8 +38,6 @@ public class ConcertSyncService {
         log.info("KOPIS 전체 데이터 동기화 시작");
 
         try{
-            syncInProgress.incrementAndGet();
-
             LocalDate startDate = LocalDate.now().minusMonths(1); // 과거 1개월
             LocalDate endDate = LocalDate.now().plusMonths(6); // 미래 6개월
 
@@ -49,7 +47,7 @@ public class ConcertSyncService {
         } catch (Exception e) {
             log.error("전체 동기화 중 오류 발생", e);
         } finally {
-            syncInProgress.decrementAndGet();
+            finishSync();
         }
     }
 
@@ -82,7 +80,7 @@ public class ConcertSyncService {
         }catch (Exception e){
             log.error("증분 동기화 중 오류 발생", e);
         }finally {
-            syncInProgress.decrementAndGet();
+            finishSync();
         }
     }
 
@@ -142,6 +140,10 @@ public class ConcertSyncService {
     }
 
     // 동기화 상태 관리
+    public void resetSyncStatus(){
+        syncInProgress.set(0);
+    }
+
     private boolean tryStartSync(){
         return syncInProgress.compareAndSet(0, 1);
     }

--- a/src/main/java/com/BeatUp/BackEnd/Concert/service/sync/ConcertSyncExecutor.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/service/sync/ConcertSyncExecutor.java
@@ -1,0 +1,153 @@
+package com.BeatUp.BackEnd.Concert.service.sync;
+
+import com.BeatUp.BackEnd.Concert.client.KopisApiClient;
+import com.BeatUp.BackEnd.Concert.dto.response.KopisPerformanceDto;
+import com.BeatUp.BackEnd.Concert.entity.Concert;
+import com.BeatUp.BackEnd.Concert.service.ConcertService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.BeatUp.BackEnd.Concert.service.sync.DataWindowSplitter.*;
+
+
+// 실제 동기화 실행 로직
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ConcertSyncExecutor {
+
+    private final KopisApiClient kopisApiClient;
+    private final ConcertService concertService;
+    private final DataWindowSplitter dataWindowSplitter;
+
+
+    @Value("${kopis.api.delay-between-calls:200}")
+    private long delayBetweenCalls;
+
+    private static final int ROWS_PER_PAGE = 50;
+    private static final int MAX_PAGES = 10;
+
+    /**
+     * 특정 날짜 범위 동기화 (31일 제한 고려한 윈도우 분할)
+     */
+    public int syncDateRange(LocalDate startDate, LocalDate endDate){
+        if(startDate == null || endDate == null || endDate.isBefore(startDate)){
+            log.warn("잘못된 날짜 범위: {} - {}", startDate, endDate);
+            return 0;
+        }
+
+        int totalSynced = 0;
+        List<DateWindow> windows = dataWindowSplitter.splitIntoWindows(startDate, endDate);
+
+        for(DateWindow window: windows){
+            totalSynced += syncSingleWindow(window.start, window.end);
+
+            // 윈도우 간 지연
+            if(delayBetweenCalls > 0){
+                sleep(delayBetweenCalls);
+            }
+        }
+
+        return totalSynced;
+    }
+
+    /**
+     * 기존 공연 데이터 새로고침
+     */
+    public int refreshExistingConcerts(){
+        List<Concert> needsUpdate = concertService.getConcertsNeedingSync();
+        int refreshed = 0;
+
+        for(Concert concert : needsUpdate){
+            if(concert.getKopisId() == null) continue;
+
+            try{
+                var detailOpt = kopisApiClient.getPerformanceDetail(concert.getKopisId());
+                if(detailOpt.isPresent()){
+                    concertService.upsertFromKopis(detailOpt.get());
+                    refreshed++;
+                }
+
+                sleep(delayBetweenCalls);
+            } catch (Exception e) {
+                log.warn("공연 새로고침 실패: {} - {}", concert.getKopisId(), e.getMessage());
+            }
+        }
+
+        return refreshed;
+    }
+
+    /**
+     * 단일 KOPIS ID 동기화(Fallback용)
+     */
+    public Concert syncSingleKopisId(String kopisId){
+        if(kopisId == null || kopisId.trim().isEmpty()){
+            return null;
+        }
+
+        try{
+            var detailOpt = kopisApiClient.getPerformanceDetail(kopisId);
+            if(detailOpt.isPresent()){
+                Concert saved = concertService.upsertFromKopis(detailOpt.get());
+                log.info("KOPIS ID 개별 동기화 성공: {} - {}", kopisId, saved.getName());
+                return saved;
+            }else{
+                log.warn("KOPIS API에서 데이터를 찾을 수 없음: {}", kopisId);
+                return null;
+            }
+        } catch (Exception e) {
+            log.error("KOPIS ID 개별 동기화 실패: {}", kopisId, e);
+            return null;
+        }
+    }
+
+    /**
+     * 단일 윈도우 (31일 이내) 동기화
+     */
+    private int syncSingleWindow(LocalDate startDate, LocalDate endDate){
+        int windowSynced = 0;
+
+        for(int page = 1; page <= MAX_PAGES; page++){
+            List<KopisPerformanceDto> performances = kopisApiClient.searchPerformances(
+                    startDate, endDate, null, null, null, page, ROWS_PER_PAGE
+            );
+
+            if(performances.isEmpty()){
+                break; // 더 이상 데이터 없음
+            }
+
+            List<Concert> savedConcerts = concertService.batchUpsertFromKopis(performances);
+            windowSynced += savedConcerts.size();
+
+            log.debug("윈도우 {}-{} 페이지 {}-{}개 처리", startDate, endDate, page, savedConcerts.size());
+
+            // 페이지당 결과가 적으면 마지막 페이지
+            if(performances.size() < ROWS_PER_PAGE){
+                break;
+            }
+
+            // API 호출 간격 제어
+            sleep(delayBetweenCalls);
+        }
+
+        if(windowSynced > 0){
+            log.info("윈도우 동기화 완료 {}-{}: {}개", startDate, endDate, windowSynced);
+        }
+
+        return windowSynced;
+    }
+
+    private void sleep(long millis){
+        try{
+            Thread.sleep(millis);
+        }catch (InterruptedException e){
+            Thread.currentThread().interrupt();
+        }
+    }
+
+}

--- a/src/main/java/com/BeatUp/BackEnd/Concert/service/sync/DataWindowSplitter.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/service/sync/DataWindowSplitter.java
@@ -1,0 +1,45 @@
+package com.BeatUp.BackEnd.Concert.service.sync;
+
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class DataWindowSplitter {
+
+    private static final int MAX_DAYS_PER_WINDOW = 30; // KOPIS 31일 제한(시작일 포함)
+
+    /**
+     * 날짜 범위를 31일 이내로 윈도우 분할
+     */
+    List<DateWindow> splitIntoWindows(LocalDate start, LocalDate end){
+        List<DateWindow> windows = new ArrayList<>();
+        LocalDate current = start;
+
+        while(!current.isAfter(end)){
+            LocalDate windowEnd = current.plusDays(MAX_DAYS_PER_WINDOW);
+            if(windowEnd.isAfter(end)){
+                windowEnd = end;
+            }
+
+            windows.add(new DateWindow(current, windowEnd));
+            current = windowEnd.plusDays(1);
+        }
+
+        return windows;
+    }
+
+    // 날짜 윈도우 헬퍼 클래스
+    static class DateWindow{
+        final LocalDate start;
+        final LocalDate end;
+
+        DateWindow(LocalDate start, LocalDate end){
+            this.start = start;
+            this.end = end;
+        }
+    }
+}

--- a/src/main/java/com/BeatUp/BackEnd/Concert/service/sync/SyncStatus.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/service/sync/SyncStatus.java
@@ -1,0 +1,25 @@
+package com.BeatUp.BackEnd.Concert.service.sync;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SyncStatus {
+
+    private boolean isRunning;
+    private long totalConcerts;
+    private long kopisConcerts;
+    private long needsSyncCount;
+    private double kopisDataRatio;
+
+    public String getStatusMessage(){
+        if(isRunning){
+            return "동기화 진행 중";
+        }else if(needsSyncCount > 0){
+            return String.format("동기화 필요한 데이터 %d개 존재", needsSyncCount);
+        }else{
+            return "모든 데이터 최신 상태";
+        }
+    }
+}

--- a/src/main/java/com/BeatUp/BackEnd/Concert/service/sync/SyncStatusProvider.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/service/sync/SyncStatusProvider.java
@@ -1,0 +1,33 @@
+package com.BeatUp.BackEnd.Concert.service.sync;
+
+
+import com.BeatUp.BackEnd.Concert.enums.DataSource;
+import com.BeatUp.BackEnd.Concert.repository.ConcertRepository;
+import com.BeatUp.BackEnd.Concert.service.ConcertService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SyncStatusProvider {
+
+    private final ConcertRepository concertRepository;
+    private final ConcertService concertService;
+
+    /**
+     * 현재 동기화 상태 조회
+     */
+    public SyncStatus getCurrentStatus(boolean isRunning){
+        long totalConcerts = concertRepository.count();
+        long kopisConcerts = concertRepository.findByDataSource(DataSource.KOPIS).size();
+        long needsSyncCount = concertService.getConcertsNeedingSync().size();
+
+        return SyncStatus.builder()
+                .isRunning(isRunning)
+                .totalConcerts(totalConcerts)
+                .kopisConcerts(kopisConcerts)
+                .needsSyncCount(needsSyncCount)
+                .kopisDataRatio(totalConcerts > 0 ? (double) kopisConcerts / totalConcerts * 100 : 0)
+                .build();
+    }
+}

--- a/src/main/java/com/BeatUp/BackEnd/common/config/OpenApiConfig.java
+++ b/src/main/java/com/BeatUp/BackEnd/common/config/OpenApiConfig.java
@@ -18,7 +18,7 @@ public class OpenApiConfig {
                 .info(new Info()
                         .title("BEAT_UP API")
                         .version("1.0.0")
-                        .description("인증 및 프로필 관리 API"))
+                        .description("BEAT_UP API"))
                 .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
                 .components(new Components()
                         .addSecuritySchemes("bearerAuth",

--- a/src/main/java/com/BeatUp/BackEnd/common/config/SchedulingConfig.java
+++ b/src/main/java/com/BeatUp/BackEnd/common/config/SchedulingConfig.java
@@ -18,7 +18,6 @@ public class SchedulingConfig {
     /**
      * @Async 메서드가 사용할 전용 스레드 풀
      */
-    @Bean(name = "concertSyncExecutor")
     public Executor concertSyncExeuctor(){
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(3);

--- a/src/main/java/com/BeatUp/BackEnd/common/config/SchedulingConfig.java
+++ b/src/main/java/com/BeatUp/BackEnd/common/config/SchedulingConfig.java
@@ -3,7 +3,6 @@ package com.BeatUp.BackEnd.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -18,7 +17,8 @@ public class SchedulingConfig {
     /**
      * @Async 메서드가 사용할 전용 스레드 풀
      */
-    public Executor concertSyncExeuctor(){
+    @Bean(name = "concertSyncTaskExecutor")
+    public Executor concertSyncTaskExeuctor(){
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(3);
         executor.setMaxPoolSize(5);

--- a/src/main/java/com/BeatUp/BackEnd/common/config/SchedulingConfig.java
+++ b/src/main/java/com/BeatUp/BackEnd/common/config/SchedulingConfig.java
@@ -1,0 +1,33 @@
+package com.BeatUp.BackEnd.common.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableScheduling // 스케줄링 활성화
+@EnableAsync // 비동기 실행 활성화
+public class SchedulingConfig {
+
+    /**
+     * @Async 메서드가 사용할 전용 스레드 풀
+     */
+    @Bean(name = "concertSyncExecutor")
+    public Executor concertSyncExeuctor(){
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(3);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("ConcertSync-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(30);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/BeatUp/BackEnd/common/config/SecurityConfig.java
+++ b/src/main/java/com/BeatUp/BackEnd/common/config/SecurityConfig.java
@@ -53,6 +53,7 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-resources/**", "/webjars/**").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers("/ping", "/test/**").permitAll()
+                        .requestMatchers("/webjars/**").permitAll()
                         .requestMatchers("/auth/login").permitAll()
                         .requestMatchers("/concert/concerts/**").permitAll()
                         .requestMatchers("/ws/**").permitAll()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,14 @@ spring:
     type: caffeine
     caffeine:
       spec: maximumSize=1000, expireAfterWrite=1h
+  config:
+    import: optional:file:.env[.properties]
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+    deserialization:
+      fail-on-unknown-properties: false
+    time-zone: Asia/Seoul
 
 
   server:
@@ -19,8 +27,8 @@ kopis:
     service-key: ${KOPIS_SERVICE_KEY:your-default-key-for-dev}
     timeout: 30000
     max-retry: 3
-    delay-between-calls: 200
-    response-format: json
+    delay-between-calls: 1000
+    response-format: xml
 
 logging:
   level:
@@ -38,6 +46,9 @@ springdoc:
     path: /api-docs
   swagger-ui:
     path: /swagger-ui.html
+    url: /api-docs
+    disable-swagger-default-url: false
+    try-it-out-enabled: true
 
 # firebase 인증 키
 firebase:

--- a/src/test/java/com/BeatUp/BackEnd/KopisApiClientIntegrationTest.java
+++ b/src/test/java/com/BeatUp/BackEnd/KopisApiClientIntegrationTest.java
@@ -74,7 +74,7 @@ class KopisApiClientIntegrationTest {
         log.info("테스트할 공연 ID: {}", testId);
 
         // When
-        Optional<KopisPerformanceDto> result = kopisApiClient.getPerformanceDetails(testId);
+        Optional<KopisPerformanceDto> result = kopisApiClient.getPerformanceDetail(testId);
 
         // Then
         assertThat(result).isPresent();


### PR DESCRIPTION
## 개요
> #29 의 KOPIS API 클라이언트와  #30 의 엔티티 확장을 기반으로 자동 동기화 시스템을 구축하고, 동시에 ConcertSyncService의 코드가 너무 길어져 이 로직을 단일 책임 원칙(SRP)에 따라 4개의 독립적인 클래스로 분리하였습니다.


## 목표
- 매일 자동 동기화: 매일 새벽 2시 전체 동기화(최신 공연 데이터 유지)
- API 호출 제한 준수: 31일 윈도우 분할 + 페이징 + 호출 간격 제어
- Fallback 구현: KOPIS ID 개별 동기화

## 클래스별 책임 분할

## ConcertSyncService.java (스케줄링 담당)
- @Scheduled 기반 전체/증분 동기화 스케줄링
- 수동 동기화 트리거 메서드들
- AtomicInteger 기반 동시성 제어
- 실제 로직은 다른 컴포넌트에 위임하는 오케스트레이터 역할

## ConcetSyncExecutor.java (동기화 실행 엔진)
- KOPIS API 호출 및 데이터 처리 로직
- 날짜 범위별/기존 데이터/단일 ID 동기화 실행
- API 호출 간격 제어 및 에러 처리
- 페이징 및 배치 처리 로직

## DataWindowSplitter.java (날짜 분할 유틸리티)
- KOPIS API 31일 제한 대응을 위한 날짜 윈도우 분할
- DataWindow 내부 클래스로 시작/종료 날짜 캡슐화
- 재사용 가능한 유틸리티 컴포넌트

## SyncStatusProvider.java (상태 조회)
- 현재 동기화 상태 정보 조회(총 공연 수, KOPIS 공연 수 등)
- KOPIS 데이터 비율 계산
- SyncStatus 객체 생성 및 반환

## swagger 자료
<img width="1636" height="1208" alt="image" src="https://github.com/user-attachments/assets/b0854ff1-6a86-42d0-9773-db3dfee68497" />
<img width="2514" height="1372" alt="image" src="https://github.com/user-attachments/assets/23dedbf6-b089-471a-ae75-6b3339124d84" />

<img width="1898" height="1342" alt="image" src="https://github.com/user-attachments/assets/8fc4c502-8114-41d0-8921-826bd95a71d8" />

<img width="2486" height="1426" alt="image" src="https://github.com/user-attachments/assets/8be2d67d-a9c2-47cc-a9ed-31d9e32d16bc" />

<img width="2518" height="1380" alt="image" src="https://github.com/user-attachments/assets/116ec15a-6a74-47e2-bf74-91127c5e21a0" />

<img width="1271" height="716" alt="스크린샷 2025-09-10 오전 3 30 48" src="https://github.com/user-attachments/assets/000ad35d-ac37-43de-961c-8a742b27b1fb" />
<img width="1277" height="723" alt="스크린샷 2025-09-10 오전 3 31 02" src="https://github.com/user-attachments/assets/2c4ac4f1-6a04-48b3-943b-9652eb7f73a3" />

<img width="3244" height="1530" alt="image" src="https://github.com/user-attachments/assets/2aa79a67-0626-4f90-a703-1e55bb8df1a9" />
