### PR TITLE
[FEAT]: 카테고리 매핑 및 Places Service 구현

### DIFF
--- a/src/main/java/com/BeatUp/BackEnd/Places/Mapper/CategoryMapper.java
+++ b/src/main/java/com/BeatUp/BackEnd/Places/Mapper/CategoryMapper.java
@@ -1,0 +1,86 @@
+package com.BeatUp.BackEnd.Places.Mapper;
+
+
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+public class CategoryMapper {
+
+    // 사용자 친화적 카테고리 -> 카카오 코드 매핑
+    private static final Map<String, List<String>> CATEGORY_MAPPING = Map.of(
+            "음식점", Arrays.asList("FD6"), // 일반 음식점
+            "카페", Arrays.asList("CE7"), // 카페
+            "패스트푸드", Arrays.asList("FD7"), // 패스트푸드
+            "편의시설", Arrays.asList("CS2", "PK6"), // 편의점만
+            "주차", Arrays.asList("PK6"), // 주차장만
+            "오락거리", Arrays.asList("AT4", "CT1") // 관광명소 + 문화시설
+    );
+
+    // 카카오 코드 -> 사용자 친화적 이름 매핑
+    private static final Map<String, String> CODE_TO_NAME = Map.of(
+            "FD6", "음식점",
+            "FD7", "패스트푸드",
+            "CE7", "카페",
+            "CS2", "편의점",
+            "PK6", "주차장",
+            "AT4", "관광명소",
+            "CT1", "문화시설"
+    );
+
+    // 기본 카테고리
+    private static final List<String> DEFAULT_CATEGORIES = Arrays.asList("FD6", "CE7", "CS2");
+
+    /**
+     * 사용자 카테코리 목록을 카카오 코드 목록으로 변환
+     */
+    public List<String> getKakaoCategoryCodes(List<String> userCategories){
+        if(userCategories == null || userCategories.isEmpty()){
+            return DEFAULT_CATEGORIES;
+        }
+
+        return userCategories.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(category -> !category.isEmpty())
+                .flatMap(category -> getKakaoCategoryCodes(category).stream())
+                .distinct()
+                .limit(6)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 단일 사용자 카테고리를 카카오 코드로 변환
+     */
+    public List<String> getKakaoCategoryCodes(String userCategory){
+        if(userCategory == null || userCategory.isEmpty()){
+            return DEFAULT_CATEGORIES;
+        }
+
+        return CATEGORY_MAPPING.getOrDefault(userCategory.trim(),
+                Arrays.asList("FD6")); // 기본값: 음식점
+    }
+
+    /**
+     * 카카오 코드를 사용자 친화적 이름으로 변환
+     */
+    public String getUserFriendlyName(String kakaoCode){
+        return CODE_TO_NAME.getOrDefault(kakaoCode, "기타");
+    }
+
+    /**
+     * 지원하는 모든 카테고리 목록 반환 (API 문서용)
+     */
+    public Set<String> getSupportedCategories(){
+        return CATEGORY_MAPPING.keySet();
+    }
+
+    /**
+     * 카테고리 유효성 검증
+     */
+    public boolean isValidCategory(String category){
+        return category != null && CATEGORY_MAPPING.containsKey(category.trim());
+    }
+}

--- a/src/main/java/com/BeatUp/BackEnd/Places/dto/request/NearbySearchRequest.java
+++ b/src/main/java/com/BeatUp/BackEnd/Places/dto/request/NearbySearchRequest.java
@@ -1,0 +1,56 @@
+package com.BeatUp.BackEnd.Places.dto.request;
+
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NearbySearchRequest {
+
+    @NotNull(message = "위도는 필수입니다")
+    @DecimalMin(value = "-90.0", message = "위도는 -90도 이상이어야 합니다.")
+    @DecimalMax(value = "90.0", message = "위도는 90도 이상이어야 합니다.")
+    private Double lat;
+
+    @NotNull(message = "경도는 필수입니다")
+    @DecimalMin(value = "-180.0", message = "경도는 -180도 이상이어야 합니다.")
+    @DecimalMax(value = "180.0", message = "경도는 180도 이상이어야 합니다.")
+    private Double lng;
+
+    @Min(value = 100, message = "검색 반경은 최소 100m입니다.")
+    @Max(value = 5000, message = "검색 반경은 최대 5km입니다.")
+    @Builder.Default
+    private Integer radius = 1000;
+
+    private List<String> categories; // 사용자 친화적 카테고리("카페", "음식점")
+
+    private Boolean openNow;
+
+    @Min(value = 1, message = "결과 개수는 최소 1개입니다.")
+    @Max(value = 50, message = "결과 개수는 최대 50개입니다.")
+    @Builder.Default
+    private Integer limit = 20;
+
+    @Min(value = 0, message = "오프셋은 0이상이어야 합니다.")
+    @Builder.Default
+    private Integer offset = 0;
+
+    // 캐싱용 키
+    public String getCacheKey(){
+        double latBucket = Math.round(lat * 10000.0)/10000.0;
+        double lngBucket = Math.round(lng * 10000.0)/10000.0;
+        String categoriesStr = categories != null ?
+                String.join(",", categories.stream().sorted().toList()): "";
+
+        return String.format("places:v2:%.4f:%.4f:%d:%s:%s:%d:%d",
+                latBucket, lngBucket, radius, categoriesStr, openNow, limit, offset);
+    }
+}

--- a/src/main/java/com/BeatUp/BackEnd/Places/dto/response/CategoryResponse.java
+++ b/src/main/java/com/BeatUp/BackEnd/Places/dto/response/CategoryResponse.java
@@ -1,0 +1,15 @@
+package com.BeatUp.BackEnd.Places.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryResponse {
+    private String name; // 사용자 친화적 이름
+    private String code; // 카카오 카테고리 코드
+}

--- a/src/main/java/com/BeatUp/BackEnd/Places/dto/response/DistanceResponse.java
+++ b/src/main/java/com/BeatUp/BackEnd/Places/dto/response/DistanceResponse.java
@@ -1,0 +1,15 @@
+package com.BeatUp.BackEnd.Places.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DistanceResponse {
+    private Integer meters;
+    private String displayText; // "내 위치에서 300m"
+}

--- a/src/main/java/com/BeatUp/BackEnd/Places/dto/response/LocationResponse.java
+++ b/src/main/java/com/BeatUp/BackEnd/Places/dto/response/LocationResponse.java
@@ -1,0 +1,24 @@
+package com.BeatUp.BackEnd.Places.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LocationResponse {
+    private Double lat;
+    private Double lng;
+
+    public static LocationResponse of(double lat, double lng){
+        return LocationResponse.builder()
+                .lat(lat)
+                .lng(lng)
+                .build();
+    }
+}
+

--- a/src/main/java/com/BeatUp/BackEnd/Places/dto/response/NearbySearchResponse.java
+++ b/src/main/java/com/BeatUp/BackEnd/Places/dto/response/NearbySearchResponse.java
@@ -1,0 +1,29 @@
+package com.BeatUp.BackEnd.Places.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NearbySearchResponse {
+    private List<PlaceResponse> places;
+    private Integer totalCount;
+    private LocationResponse searchCenter;
+    private Boolean cacheHit;
+
+    // 검색 메타 정보
+    private List<String> appliedCategories;
+    private Integer searchRadius;
+
+    public NearbySearchResponse withCacheHit(Boolean cacheHit){
+        this.cacheHit = cacheHit;
+        return this;
+    }
+}

--- a/src/main/java/com/BeatUp/BackEnd/Places/dto/response/PlaceResponse.java
+++ b/src/main/java/com/BeatUp/BackEnd/Places/dto/response/PlaceResponse.java
@@ -1,0 +1,23 @@
+package com.BeatUp.BackEnd.Places.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlaceResponse {
+    private String id; // 카카오 place_id
+    private String name;
+    private String address;
+    private String phone;
+
+    private CategoryResponse category;
+    private LocationResponse location;
+    private DistanceResponse distance;
+    private String placeUrl;
+
+}

--- a/src/main/java/com/BeatUp/BackEnd/Places/service/PlaceService.java
+++ b/src/main/java/com/BeatUp/BackEnd/Places/service/PlaceService.java
@@ -1,0 +1,200 @@
+package com.BeatUp.BackEnd.Places.service;
+
+import com.BeatUp.BackEnd.Places.Mapper.CategoryMapper;
+import com.BeatUp.BackEnd.Places.client.KakaoLocalApiClient;
+import com.BeatUp.BackEnd.Places.dto.request.NearbySearchRequest;
+import com.BeatUp.BackEnd.Places.dto.response.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class PlaceService {
+
+    private final KakaoLocalApiClient kakaoClient;
+    private final CategoryMapper categoryMapper;
+
+    /**
+     * 주변 장소 검색 메서드
+     */
+    public NearbySearchResponse searchNearby(NearbySearchRequest request){
+        log.debug("주변 장소 검색 시작 - lat: {}, lng: {}, radius: {}m, categories:{}",
+                request.getLat(), request.getLng(), request.getRadius(), request.getCategories());
+
+        // 1. 카테고리 매핑
+        List<String> kakaoCodes = categoryMapper.getKakaoCategoryCodes(request.getCategories());
+        log.debug("매핑된 카카오 카테고리: {}", kakaoCodes);
+
+        // 2. 카카오맵 API 호출 및 결과 수정
+        List<PlaceResponse> allPlaces = new ArrayList<>();
+
+        for(String categoryCode: kakaoCodes){
+            try{
+                KakaoPlaceSearchResponse kakaoResponse = kakaoClient.searchByCategory(
+                        request.getLat(), request.getLng(), request.getRadius(), categoryCode, 15
+                );
+
+                if(kakaoResponse != null && kakaoResponse.getDocuments() != null){
+                    List<PlaceResponse> categoryPlaces = kakaoResponse.getDocuments().stream()
+                            .map(doc -> convertToPlaceResponse(doc, request))
+                            .collect(Collectors.toList());
+
+                    allPlaces.addAll(categoryPlaces);
+                    log.debug("카테고리 {} 검색 완료 - 결과 {}개", categoryCode,categoryPlaces.size());
+                }
+            }catch(Exception e){
+                log.warn("카테고리 {} 검색 실패: {}개", categoryCode, e.getMessage());
+                // 일부 카테고리 실패해도 다른 카테고리 결과는 반환
+            }
+        }
+
+        // 3. 중복 제거 및 정렬
+        List<PlaceResponse> processPlaces = deduplicateAndSort(allPlaces, request);
+
+        // 4. 응답 생성
+        NearbySearchResponse response = NearbySearchResponse.builder()
+                .places(processPlaces)
+                .totalCount(processPlaces.size())
+                .searchCenter(LocationResponse.of(request.getLat(), request.getLng()))
+                .appliedCategories(request.getCategories())
+                .searchRadius(request.getRadius())
+                .cacheHit(false)
+                .build();
+
+        log.info("주변 장소 검색 완료 - 총 {}개 출력", processPlaces.size());
+        return response;
+    }
+
+    /**
+     * 카카오맵 응답을 PlaceResponse로 반환
+     */
+    private PlaceResponse convertToPlaceResponse(
+            KakaoPlaceSearchResponse.PlaceDocument doc,
+            NearbySearchRequest request
+    ){
+        // 카카오 API가 제공하는 distance 사용(미터 단위)
+        int distaceMeters;
+        try{
+            distaceMeters = Integer.parseInt(doc.getDistance());
+        } catch (NumberFormatException e) {
+            // distance가 없는 경우 Haversine 공식으로 계산
+            distaceMeters = (int) Math.round(caculateDistance(
+                request.getLat(), request.getLng(),
+                    Double.parseDouble(doc.getY()),  Double.parseDouble(doc.getX())
+            ));
+        }
+
+        return PlaceResponse.builder()
+                .id(doc.getId())
+                .name(doc.getPlaceName())
+                .address(preferRoadAddress(doc.getRoadAddressName(), doc.getAddressName()))
+                .phone(cleanPhoneNumber(doc.getPhone()))
+                .category(CategoryResponse.builder()
+                        .name(categoryMapper.getUserFriendlyName(doc.getCategoryGroupCode()))
+                        .code(doc.getCategoryGroupCode())
+                        .build())
+                .location(LocationResponse.builder()
+                        .lat(Double.parseDouble(doc.getY()))
+                        .lng(Double.parseDouble(doc.getX()))
+                        .build())
+                .distance(DistanceResponse.builder()
+                        .meters(distaceMeters)
+                        .displayText(formatDistance(distaceMeters))
+                        .build())
+                .placeUrl(doc.getPlaceUrl())
+                .build();
+    }
+
+    /**
+     * 중복 제거 및 거리순 정렬
+     */
+    private List<PlaceResponse> deduplicateAndSort(List<PlaceResponse> places, NearbySearchRequest request){
+        // 1. 중복 제거(같은 ID의 장소, 더 상세한 정보를 가진 것 선택)
+        Map<String, PlaceResponse> uniqueReplaces = places.stream()
+                .collect(Collectors.toMap(
+                        PlaceResponse::getId,
+                        Function.identity(),
+                        (existing, replacement) -> {
+                            // 전화번호가 있는 것을 우선 선택
+                            if(replacement.getPhone() != null && existing.getPhone() == null){
+                                return replacement;
+                            }
+                            return existing;
+                        }
+                ));
+
+        // 2. 거리순 정렬 후 페이징 적용
+        return uniqueReplaces.values().stream()
+                .sorted(Comparator.comparing(place -> place.getDistance().getMeters()))
+                .skip(request.getOffset())
+                .limit(request.getLimit())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Haversine 공식을 이용한 거리 계산
+     */
+    private double caculateDistance(double lat1, double lng1, double lat2, double lng2){
+        final double R = 6371000; // 지구 반지름
+
+        double lat1Rad = Math.toRadians(lat1);
+        double lat2Rad = Math.toRadians(lat2);
+        double deltaLatRad = Math.toRadians(lat2 - lat1);
+        double deltaLngRad = Math.toRadians(lng2 - lng1);
+
+        double a = Math.sin(deltaLatRad / 2) * Math.sin(deltaLatRad / 2) +
+                Math.cos(lat1Rad) * Math.cos(lat2Rad) +
+                Math.sin(deltaLngRad / 2) * Math.sin(deltaLngRad / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return R * c;
+    }
+
+    /**
+     * 거리를 사용자 친화적 형태로 포맷팅
+     */
+    private String formatDistance(int meters){
+        if(meters < 1000){
+            return String.format("내 위치에서 %dm", meters);
+        }else{
+            double km = meters / 1000.0;
+            if(km < 10){
+                return String.format("내 위치에서 %.1fkm", km);
+            }else {
+                return String.format("내 위치에서 %dkm", (int)Math.round(km));
+            }
+        }
+    }
+
+    /**
+     * 도로명 주소 우선 선택
+     */
+    private String preferRoadAddress(String roadAddress, String address){
+        if(roadAddress != null && !roadAddress.trim().isEmpty()){
+            return roadAddress.trim();
+        }
+        return address != null ?  address.trim() : "";
+    }
+
+    /**
+     * 전화번호 정제
+     */
+    private String cleanPhoneNumber(String phone){
+        if(phone == null || phone.trim().isEmpty()){
+            return null;
+        }
+        return phone.trim().replaceAll("\\s+", " ");
+    }
+}

--- a/src/test/java/com/BeatUp/BackEnd/KAKAOAPI/CategoryMapperTest.java
+++ b/src/test/java/com/BeatUp/BackEnd/KAKAOAPI/CategoryMapperTest.java
@@ -1,0 +1,85 @@
+package com.BeatUp.BackEnd.KAKAOAPI;
+
+import com.BeatUp.BackEnd.Places.Mapper.CategoryMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class CategoryMapperTest {
+
+    private final CategoryMapper categoryMapper = new CategoryMapper();
+
+    @Test
+    @DisplayName("사용자 카테고리를 카카오 코드로 정확히 매핑")
+    void getKakaoCategoryCodes_SingleCategory_Success(){
+        // Given & When
+        List<String> result = categoryMapper.getKakaoCategoryCodes("음식점");
+
+        // Then
+        assertThat(result).containsExactly("FD6");
+    }
+
+    @Test
+    @DisplayName("편의시설은 편의점과 주차장 모두 매핑")
+    void getKakaoCategoryCodes_ConvenienceCategory_MultipleCode(){
+        // Given & When
+        List<String> result = categoryMapper.getKakaoCategoryCodes("편의시설");
+
+        // Then
+        assertThat(result).containsExactlyInAnyOrder("CS2", "PK6");
+    }
+
+    @Test
+    @DisplayName("여러 카테고리 입력 시 중복 제거하여 반환")
+    void getKakaoCategoryCodes_MultipleCategories_Deduplicated(){
+        // Given
+        List<String> userCategories = Arrays.asList("음식점", "카페", "편의시설");
+
+        // When
+        List<String> result = categoryMapper.getKakaoCategoryCodes(userCategories);
+
+        // Then
+        assertThat(result).containsExactlyInAnyOrder("FD6", "CE7", "CS2", "PK6");
+        assertThat(result).doesNotHaveDuplicates();
+    }
+
+    @Test
+    @DisplayName("null 또는 빈 카테고리 반환 시 기본 값 반환")
+    void getKakaoCategoryCodes_NullOrEmpty_DefaultCategories(){
+        // When
+        List<String> nullResult = categoryMapper.getKakaoCategoryCodes((List<String>) null);
+        List<String> emptyResult = categoryMapper.getKakaoCategoryCodes(Collections.emptyList());
+
+        // Then
+        assertThat(nullResult).containsExactlyInAnyOrder("FD6", "CE7", "CS2");
+        assertThat(emptyResult).containsExactlyInAnyOrder("FD6", "CE7", "CS2");
+    }
+
+    @Test
+    @DisplayName("카카오 코드를 사용자 친화적 이름으로 반환")
+    void getUserFriendlyName_ValidCode_CorrectName(){
+        // When & Then
+        assertThat(categoryMapper.getUserFriendlyName("FD6")).isEqualTo("음식점");
+        assertThat(categoryMapper.getUserFriendlyName("CE7")).isEqualTo("카페");
+        assertThat(categoryMapper.getUserFriendlyName("CS2")).isEqualTo("편의점");
+        assertThat(categoryMapper.getUserFriendlyName("INVALID")).isEqualTo("기타");
+    }
+
+    @Test
+    @DisplayName("카테고리 유효성 검증")
+    void isValidCategory_ValidAndInvalid_CorrectValidation(){
+        // When & Then
+        assertThat(categoryMapper.isValidCategory("음식점")).isTrue();
+        assertThat(categoryMapper.isValidCategory("카페")).isTrue();
+        assertThat(categoryMapper.isValidCategory("존재하지 않는 카테고리")).isFalse();
+        assertThat(categoryMapper.isValidCategory(null)).isFalse();
+        assertThat(categoryMapper.isValidCategory("")).isFalse();
+    }
+}

--- a/src/test/java/com/BeatUp/BackEnd/KAKAOAPI/KakaoMapApiTest.java
+++ b/src/test/java/com/BeatUp/BackEnd/KAKAOAPI/KakaoMapApiTest.java
@@ -1,19 +1,15 @@
-package com.BeatUp.BackEnd;
+package com.BeatUp.BackEnd.KAKAOAPI;
 
 import com.BeatUp.BackEnd.Places.client.KakaoLocalApiClient;
 import com.BeatUp.BackEnd.Places.config.KakaoApiConfig;
 import com.BeatUp.BackEnd.Places.dto.response.KakaoPlaceSearchResponse;
 import com.BeatUp.BackEnd.Places.exception.KakaoApiException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;

--- a/src/test/java/com/BeatUp/BackEnd/KOPISAPI/KopisApiClientIntegrationTest.java
+++ b/src/test/java/com/BeatUp/BackEnd/KOPISAPI/KopisApiClientIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.BeatUp.BackEnd;
+package com.BeatUp.BackEnd.KOPISAPI;
 
 
 import com.BeatUp.BackEnd.Concert.client.KopisApiClient;

--- a/src/test/java/com/BeatUp/BackEnd/Places/PlacesServiceTest.java
+++ b/src/test/java/com/BeatUp/BackEnd/Places/PlacesServiceTest.java
@@ -1,0 +1,229 @@
+package com.BeatUp.BackEnd.Places;
+
+
+import com.BeatUp.BackEnd.Places.Mapper.CategoryMapper;
+import com.BeatUp.BackEnd.Places.client.KakaoLocalApiClient;
+import com.BeatUp.BackEnd.Places.dto.request.NearbySearchRequest;
+import com.BeatUp.BackEnd.Places.dto.response.KakaoPlaceSearchResponse;
+import com.BeatUp.BackEnd.Places.dto.response.NearbySearchResponse;
+import com.BeatUp.BackEnd.Places.dto.response.PlaceResponse;
+import com.BeatUp.BackEnd.Places.service.PlaceService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PlacesServiceTest {
+
+    @Mock
+    private KakaoLocalApiClient kakaoClient;
+
+    @Mock
+    private CategoryMapper categoryMapper;
+
+    private PlaceService placeService;
+
+    @BeforeEach
+    void setUp(){
+        // PlaceService 생성자에 Mock 객체들을 직접 주입
+        // PlaceService(KakaoLocalApiClient kakaoClient, CategoryMappter categoryMapper) 순서
+        placeService = new PlaceService(kakaoClient, categoryMapper);
+    }
+
+    @Test
+    @DisplayName("주변 장소 검색 성공")
+    void searchNearby_Success(){
+        // Given
+        NearbySearchRequest request = NearbySearchRequest.builder()
+                .lat(37.5665)
+                .lng(126.9780)
+                .radius(100)
+                .categories(Arrays.asList("음식점", "카페"))
+                .limit(10)
+                .offset(0)
+                .build();
+
+        // CategoryMapper Mock 설정
+        when(categoryMapper.getKakaoCategoryCodes(request.getCategories()))
+                .thenReturn(Arrays.asList("FD6", "CE7"));
+
+        // 카카오 API 응답 모킹
+        KakaoPlaceSearchResponse mockResponse = createMockResponse();
+        when(kakaoClient.searchByCategory(anyDouble(), anyDouble(), anyInt(), anyString(), anyInt()))
+                .thenReturn(mockResponse);
+
+        // When
+        NearbySearchResponse result = placeService.searchNearby(request);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getPlaces()).isNotEmpty();
+        assertThat(result.getTotalCount()).isGreaterThan(0);
+        assertThat(result.getSearchCenter().getLat()).isEqualTo(37.5665);
+        assertThat(result.getSearchCenter().getLng()).isEqualTo(126.9780);
+
+        // 카카오 API가 각 카테고리별로 호출되었는지 확인
+        verify(kakaoClient, times(2)).searchByCategory(anyDouble(), anyDouble(), anyInt(), anyString(), anyInt());
+        verify(categoryMapper).getKakaoCategoryCodes(request.getCategories());
+    }
+
+    @Test
+    @DisplayName("중복 제거 및 거리순 정렬 확인")
+    void searchNearby_DeduplicationAndSorting(){
+
+        // Given
+        NearbySearchRequest request = NearbySearchRequest.builder()
+                .lat(37.5665)
+                .lng(126.9780)
+                .categories(Arrays.asList("카페"))
+                .limit(10)
+                .build();
+
+        when(categoryMapper.getKakaoCategoryCodes(request.getCategories()))
+                .thenReturn(Arrays.asList("CE7"));
+        when(categoryMapper.getUserFriendlyName("CE7")).thenReturn("카페");
+
+        // 거리가 다른 두 장소와 중복 장소 생성
+        KakaoPlaceSearchResponse mockResponse = createMockResponseWithDuplication();
+        when(kakaoClient.searchByCategory(anyDouble(), anyDouble(), anyInt(), anyString(), anyInt()))
+                .thenReturn(mockResponse);
+
+        // When
+        NearbySearchResponse result = placeService.searchNearby(request);
+
+        // Then
+        assertThat(result.getPlaces()).hasSize(2); // 중복 제거로 2개만
+        // 거리순 정렬 확인(가까운 순)
+        assertThat(result.getPlaces().get(0).getDistance().getMeters())
+                .isLessThan(result.getPlaces().get(1).getDistance().getMeters());
+    }
+
+
+    @Test
+    @DisplayName("거리 포맷팅 정확성 확인")
+    void searchNearby_DistanceFormatting(){
+        // Given
+        NearbySearchRequest request = NearbySearchRequest.builder()
+                .lat(37.5665)
+                .lng(126.9780)
+                .categories(Arrays.asList("카페"))
+                .build();
+
+        when(categoryMapper.getKakaoCategoryCodes(request.getCategories()))
+                .thenReturn(Arrays.asList("CE7"));
+        when(categoryMapper.getUserFriendlyName("CE7")).thenReturn("카페");
+
+        KakaoPlaceSearchResponse mockResponse = createMockResponseWithVariousDistances();
+        when(kakaoClient.searchByCategory(anyDouble(), anyDouble(), anyInt(), anyString(), anyInt()))
+                .thenReturn(mockResponse);
+
+        // When
+        NearbySearchResponse result = placeService.searchNearby(request);
+
+        // Then
+        List<PlaceResponse> places = result.getPlaces();
+        assertThat(places.get(0).getDistance().getDisplayText()).contains("내 위치에서").contains("m");
+        assertThat(places.get(1).getDistance().getDisplayText()).contains("내 위치에서").contains("km");
+
+    }
+
+    private KakaoPlaceSearchResponse createMockResponse(){
+        KakaoPlaceSearchResponse.PlaceDocument doc = new KakaoPlaceSearchResponse.PlaceDocument();
+        doc.setId("12345");
+        doc.setPlaceName("테스트 카페");
+        doc.setCategoryGroupCode("CE7");
+        doc.setPhone("02-1234-5678");
+        doc.setAddressName("서울 강남구 테스트동 123");
+        doc.setRoadAddressName("서울 강남구 테스트로 123");
+        doc.setX("126.9780");
+        doc.setY("37.5665");
+        doc.setDistance("100");
+        doc.setPlaceUrl("http://place.map.kakao.com/12345");
+
+        KakaoPlaceSearchResponse.Meta meta = new KakaoPlaceSearchResponse.Meta();
+        meta.setTotalCount(1);
+
+        return KakaoPlaceSearchResponse.builder()
+                .meta(meta)
+                .documents(Arrays.asList(doc))
+                .build();
+    }
+
+    private KakaoPlaceSearchResponse createMockResponseWithDuplication(){
+        KakaoPlaceSearchResponse.PlaceDocument doc1 = new KakaoPlaceSearchResponse.PlaceDocument();
+        doc1.setId("1");
+        doc1.setPlaceName("가까운 카페");
+        doc1.setCategoryGroupCode("CE7");
+        doc1.setDistance("100");
+        doc1.setY("37.5665");
+        doc1.setX("126.9780");
+        doc1.setAddressName("주소1");
+        doc1.setPlaceUrl("http://place.map.kakao.com/1");
+
+        KakaoPlaceSearchResponse.PlaceDocument doc2 = new KakaoPlaceSearchResponse.PlaceDocument();
+        doc2.setId("2");
+        doc2.setPlaceName("먼 카페");
+        doc2.setCategoryGroupCode("CE7");
+        doc2.setDistance("500");
+        doc2.setY("37.5670");
+        doc2.setX("126.9785");
+        doc2.setAddressName("주소2");
+        doc2.setPlaceUrl("http://place.map.kakao.com/2");
+
+        // 중복(같은 ID)
+        KakaoPlaceSearchResponse.PlaceDocument doc3 = new KakaoPlaceSearchResponse.PlaceDocument();
+        doc3.setId("1");
+        doc3.setPlaceName("중복 카페");
+        doc3.setCategoryGroupCode("CE7");
+        doc3.setDistance("105");
+        doc3.setY("37.5665");
+        doc3.setX("126.9780");
+        doc3.setAddressName("주소1");
+        doc3.setPlaceUrl("http://place.map.kakao.com/1");
+
+        return KakaoPlaceSearchResponse.builder()
+                .documents(Arrays.asList(doc1, doc2, doc3))
+                .meta(new KakaoPlaceSearchResponse.Meta())
+                .build();
+    }
+
+    private KakaoPlaceSearchResponse createMockResponseWithVariousDistances() {
+        KakaoPlaceSearchResponse.PlaceDocument doc1 = new KakaoPlaceSearchResponse.PlaceDocument();
+        doc1.setId("1");
+        doc1.setPlaceName("가까운 장소");
+        doc1.setCategoryGroupCode("CE7");
+        doc1.setDistance("300"); // 300m
+        doc1.setY("37.5665");
+        doc1.setX("126.9780");
+        doc1.setAddressName("주소1");
+        doc1.setPlaceUrl("http://place.map.kakao.com/1");
+
+        KakaoPlaceSearchResponse.PlaceDocument doc2 = new KakaoPlaceSearchResponse.PlaceDocument();
+        doc2.setId("2");
+        doc2.setPlaceName("먼 장소");
+        doc2.setCategoryGroupCode("CE7");
+        doc2.setDistance("1500"); // 1.5km
+        doc2.setY("37.5670");
+        doc2.setX("126.9785");
+        doc2.setAddressName("주소2");
+        doc2.setPlaceUrl("http://place.map.kakao.com/2");
+
+        return KakaoPlaceSearchResponse.builder()
+                .documents(Arrays.asList(doc1, doc2))
+                .meta(new KakaoPlaceSearchResponse.Meta())
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 연관 이슈
> Closes #40 

## 개요
> 카카오 로컬 API 기반 장소 검색을 위한 비즈니스 로직 구현, 사용자 친화적 카테고리 매핑과 데이터 처리 파이프라인을 통해 검색 경험 제공

## 주요 변경사항
- CategoryMapper 
   -  사용자 친화적 매핑: "음식점", "카페", "편의시설" -> 카카오 API 코드 자동 변환
   -  다중 코드 지원: "편의시설" -> ["CS2", "PK6"] (편의점 + 주차장)
   - 기본값: 카테고리 미지정 시 음식점/카페/편의점 자동 검색
   - 유효성 검증
- PlacesService 
   - 병렬 다중 검색: 카테고리별 동시 API 호출로 결과 다양성 극대화
   - 중복 제거: 동일 장소 ID 기준, 상세 정보 우선 선택 알고리즘
   - 거리 계산: 카카오 API distance + Harvesine 이중 보장  
   - 사용자 중심 표시: "내 위치에서 300m", "내 위치에서 1.2km" 자동 포맷팅