### PR TITLE
[FEAT]: Places API 컨트롤러 구현 및 전체 오류 수정

### DIFF
--- a/src/main/java/com/BeatUp/BackEnd/Chat/ChatMessage/controller/ChatMessageController.java
+++ b/src/main/java/com/BeatUp/BackEnd/Chat/ChatMessage/controller/ChatMessageController.java
@@ -3,15 +3,10 @@ package com.BeatUp.BackEnd.Chat.ChatMessage.controller;
 
 import com.BeatUp.BackEnd.Chat.ChatMessage.dto.response.ChatMessageResponse;
 import com.BeatUp.BackEnd.Chat.ChatMessage.service.ChatMessageService;
-import com.BeatUp.BackEnd.Chat.ChatRoom.dto.request.CreateRoomRequest;
-import com.BeatUp.BackEnd.Chat.ChatRoom.dto.response.RoomResponse;
-import com.BeatUp.BackEnd.Chat.ChatRoom.service.ChatRoomService;
 import com.BeatUp.BackEnd.common.util.SecurityUtil;
-import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
@@ -22,9 +17,6 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/chat")
 public class ChatMessageController {
-
-    @Autowired
-    private ChatRoomService chatRoomService;
 
     @Autowired
     private ChatMessageService chatMessageService;

--- a/src/main/java/com/BeatUp/BackEnd/Chat/ChatMessage/entity/ChatMessage.java
+++ b/src/main/java/com/BeatUp/BackEnd/Chat/ChatMessage/entity/ChatMessage.java
@@ -4,9 +4,7 @@ package com.BeatUp.BackEnd.Chat.ChatMessage.entity;
 import com.BeatUp.BackEnd.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
-import org.hibernate.annotations.CreationTimestamp;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity

--- a/src/main/java/com/BeatUp/BackEnd/Chat/ChatMessage/service/ChatMessageService.java
+++ b/src/main/java/com/BeatUp/BackEnd/Chat/ChatMessage/service/ChatMessageService.java
@@ -6,7 +6,6 @@ import com.BeatUp.BackEnd.Chat.ChatMessage.dto.response.ChatMessageResponse;
 import com.BeatUp.BackEnd.Chat.ChatMessage.entity.ChatMessage;
 import com.BeatUp.BackEnd.Chat.ChatMessage.repository.ChatMessageRepository;
 import com.BeatUp.BackEnd.Chat.ChatRoom.entity.ChatMember;
-import com.BeatUp.BackEnd.Chat.ChatRoom.entity.ChatRoom;
 import com.BeatUp.BackEnd.Chat.ChatRoom.repository.ChatMemberRepsoitory;
 import com.BeatUp.BackEnd.Chat.ChatRoom.repository.ChatRoomRepository;
 import com.BeatUp.BackEnd.User.repository.UserProfileRepository;
@@ -42,7 +41,7 @@ public class ChatMessageService {
     @Transactional
     public ChatMessageResponse sendMessage(UUID roomId, UUID senderId, ChatMessageRequest request){
         // 1. 방 존재 여부 확인
-        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+        chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다"));
 
         // 2. 맴버십 확인(현재 참여 중인 맴버만)
@@ -66,7 +65,7 @@ public class ChatMessageService {
     // 메시지 내역 조회 로직
     public List<ChatMessageResponse> getMessages(UUID roomId, UUID userId, LocalDateTime since){
         // 1. 방 존재 여부 확인
-        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+        chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다"));
 
         // 2. 방 맴버만 메시지 조회 가능(방 맴버인지)

--- a/src/main/java/com/BeatUp/BackEnd/Chat/ChatRoom/controller/ChatRoomController.java
+++ b/src/main/java/com/BeatUp/BackEnd/Chat/ChatRoom/controller/ChatRoomController.java
@@ -4,12 +4,10 @@ package com.BeatUp.BackEnd.Chat.ChatRoom.controller;
 import com.BeatUp.BackEnd.Chat.ChatRoom.dto.request.CreateRoomRequest;
 import com.BeatUp.BackEnd.Chat.ChatRoom.dto.response.RoomResponse;
 import com.BeatUp.BackEnd.Chat.ChatRoom.service.ChatRoomService;
-import com.BeatUp.BackEnd.Chat.ChatService;
 import com.BeatUp.BackEnd.common.util.SecurityUtil;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;

--- a/src/main/java/com/BeatUp/BackEnd/Chat/ChatRoom/entity/ChatMember.java
+++ b/src/main/java/com/BeatUp/BackEnd/Chat/ChatRoom/entity/ChatMember.java
@@ -4,7 +4,6 @@ package com.BeatUp.BackEnd.Chat.ChatRoom.entity;
 import com.BeatUp.BackEnd.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
-import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/BeatUp/BackEnd/Chat/ChatRoom/entity/ChatRoom.java
+++ b/src/main/java/com/BeatUp/BackEnd/Chat/ChatRoom/entity/ChatRoom.java
@@ -3,7 +3,6 @@ package com.BeatUp.BackEnd.Chat.ChatRoom.entity;
 import com.BeatUp.BackEnd.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
-import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 import java.util.UUID;

--- a/src/main/java/com/BeatUp/BackEnd/Community/Post/entity/Post.java
+++ b/src/main/java/com/BeatUp/BackEnd/Community/Post/entity/Post.java
@@ -6,10 +6,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity

--- a/src/main/java/com/BeatUp/BackEnd/Community/Post/repository/PostRepository.java
+++ b/src/main/java/com/BeatUp/BackEnd/Community/Post/repository/PostRepository.java
@@ -2,9 +2,6 @@ package com.BeatUp.BackEnd.Community.Post.repository;
 
 import com.BeatUp.BackEnd.Community.Post.entity.Post;
 import com.BeatUp.BackEnd.common.repository.StatusRepository;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;

--- a/src/main/java/com/BeatUp/BackEnd/Community/controller/CommunityController.java
+++ b/src/main/java/com/BeatUp/BackEnd/Community/controller/CommunityController.java
@@ -4,12 +4,8 @@ package com.BeatUp.BackEnd.Community.controller;
 import com.BeatUp.BackEnd.Community.Post.dto.request.CreatePostRequest;
 import com.BeatUp.BackEnd.Community.Post.dto.response.PostResponse;
 import com.BeatUp.BackEnd.Community.service.CommunityService;
-import com.BeatUp.BackEnd.common.util.SecurityUtil;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.support.PageableUtils;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/BeatUp/BackEnd/Community/service/CommunityService.java
+++ b/src/main/java/com/BeatUp/BackEnd/Community/service/CommunityService.java
@@ -20,7 +20,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/BeatUp/BackEnd/Concert/client/KopisApiClient.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/client/KopisApiClient.java
@@ -18,8 +18,6 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -42,7 +40,6 @@ public class KopisApiClient {
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
     private static final int DEFAULT_ROWS = 50;
     private static final int MAX_ROWS = 100;
-    private static final int MAX_DAYS = 31;
 
     public KopisApiClient(WebClient.Builder webClientBuilder,
                           XmlMapper xmlMapper,

--- a/src/main/java/com/BeatUp/BackEnd/Concert/config/ConcertDataLoader.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/config/ConcertDataLoader.java
@@ -2,7 +2,6 @@ package com.BeatUp.BackEnd.Concert.config;
 
 import com.BeatUp.BackEnd.Concert.entity.Concert;
 import com.BeatUp.BackEnd.Concert.repository.ConcertRepository;
-import com.BeatUp.BackEnd.Concert.service.ConcertSyncService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationRunner;
@@ -17,7 +16,6 @@ import java.time.LocalDateTime;
 public class ConcertDataLoader {
 
     private final ConcertRepository concertRepository;
-    private final ConcertSyncService concertSyncService;
 
     @Bean
     ApplicationRunner loadConcertData(){

--- a/src/main/java/com/BeatUp/BackEnd/Concert/config/KopisApiConfig.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/config/KopisApiConfig.java
@@ -13,7 +13,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
-import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 

--- a/src/main/java/com/BeatUp/BackEnd/Concert/controller/ConcertController.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/controller/ConcertController.java
@@ -5,8 +5,6 @@ import com.BeatUp.BackEnd.Concert.dto.ConcertSearchCondition;
 import com.BeatUp.BackEnd.Concert.entity.Concert;
 import com.BeatUp.BackEnd.Concert.enums.DataSource;
 import com.BeatUp.BackEnd.Concert.service.ConcertService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/BeatUp/BackEnd/Concert/enums/KopisGenre.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/enums/KopisGenre.java
@@ -2,7 +2,6 @@ package com.BeatUp.BackEnd.Concert.enums;
 
 
 import lombok.Getter;
-import org.springframework.security.core.parameters.P;
 
 @Getter
 public enum KopisGenre {

--- a/src/main/java/com/BeatUp/BackEnd/Concert/repository/ConcertCustomRepositoryImpl.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/repository/ConcertCustomRepositoryImpl.java
@@ -41,7 +41,11 @@ public class ConcertCustomRepositoryImpl implements ConcertCustomRepository{
                 .selectFrom(concert)
                 .where(conditions);
 
-        long total = query.fetchCount();
+        long total = queryFactory
+                .select(concert.count())
+                .from(concert)
+                .where(conditions)
+                .fetchOne();
 
         List<Concert> content = query
                 .orderBy(buildOrderSpecifier(condition))

--- a/src/main/java/com/BeatUp/BackEnd/Concert/service/ConcertService.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/service/ConcertService.java
@@ -8,7 +8,6 @@ import com.BeatUp.BackEnd.Concert.entity.Concert;
 import com.BeatUp.BackEnd.Concert.repository.ConcertRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -16,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;

--- a/src/main/java/com/BeatUp/BackEnd/Match/controller/MatchController.java
+++ b/src/main/java/com/BeatUp/BackEnd/Match/controller/MatchController.java
@@ -8,7 +8,6 @@ import com.BeatUp.BackEnd.common.util.SecurityUtil;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;

--- a/src/main/java/com/BeatUp/BackEnd/Match/entity/MatchGroup.java
+++ b/src/main/java/com/BeatUp/BackEnd/Match/entity/MatchGroup.java
@@ -4,10 +4,7 @@ package com.BeatUp.BackEnd.Match.entity;
 import com.BeatUp.BackEnd.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
-import lombok.Setter;
-import org.hibernate.annotations.CreationTimestamp;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity

--- a/src/main/java/com/BeatUp/BackEnd/Places/controller/PlacesController.java
+++ b/src/main/java/com/BeatUp/BackEnd/Places/controller/PlacesController.java
@@ -1,0 +1,96 @@
+package com.BeatUp.BackEnd.Places.controller;
+
+import com.BeatUp.BackEnd.Places.Mapper.CategoryMapper;
+import com.BeatUp.BackEnd.Places.dto.request.NearbySearchRequest;
+import com.BeatUp.BackEnd.Places.dto.response.NearbySearchResponse;
+import com.BeatUp.BackEnd.Places.service.PlaceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/places")
+@RequiredArgsConstructor
+@Validated
+@Slf4j
+@Tag(name = "Places API", description = "공연장 주변 장소 검색")
+public class PlacesController {
+
+    private final PlaceService placeService;
+    private final CategoryMapper categoryMapper;
+
+    @Operation(summary = "주변 장소 검색")
+    @GetMapping("/nearby")
+    public ResponseEntity<NearbySearchResponse> getNearbyPlaces(
+            @RequestParam
+            @NotNull @DecimalMin("-90.0") @DecimalMax("90.0")
+            Double lat,
+
+            @RequestParam
+            @NotNull @DecimalMin("-180.0") @DecimalMax("180.0")
+            Double lng,
+
+            @RequestParam(defaultValue = "1000")
+            @Min(100) @Max(5000)
+            Integer radius,
+
+            @RequestParam(required = false)
+            List<String> categories,
+
+            @RequestParam(required = false)
+            Boolean openNow,
+
+            @RequestParam(defaultValue = "20")
+            @Min(1)@Max(50)
+            Integer limit,
+
+            @RequestParam(defaultValue = "0")
+            @Min(0)
+            Integer offset
+    ){
+        log.info("주변 장소 검색 - lat: {}, lng: {}, radius: {}m", lat, lng, radius);
+
+        // 유효한 카테고리만 필터링
+        List<String> validCategories = categories != null ?
+                categories.stream()
+                        .filter(categoryMapper::isValidCategory)
+                        .toList() : null;
+
+        NearbySearchRequest request = NearbySearchRequest.builder()
+                .lat(lat)
+                .lng(lng)
+                .radius(radius)
+                .categories(validCategories)
+                .openNow(openNow)
+                .limit(limit)
+                .offset(offset)
+                .build();
+
+        NearbySearchResponse response = placeService.searchNearby(request);
+
+        log.info("검색 완료 - 결과: {}개", response.getTotalCount());
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "지원 카테고리 목록")
+    @GetMapping("/categories")
+    public ResponseEntity<Map<String, Object>> getSupportedCategories(){
+        List<String> categories = List.of(
+                "음식점", "카페", "패스트푸드", "편의시설", "편의점", "주차", "오락거리"
+        );
+
+        return ResponseEntity.ok(Map.of("categories", categories));
+    }
+}

--- a/src/main/java/com/BeatUp/BackEnd/RideRequest/entity/RideRequest.java
+++ b/src/main/java/com/BeatUp/BackEnd/RideRequest/entity/RideRequest.java
@@ -4,7 +4,6 @@ package com.BeatUp.BackEnd.RideRequest.entity;
 import com.BeatUp.BackEnd.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.UUID;

--- a/src/main/java/com/BeatUp/BackEnd/RideRequest/repository/RideRequestRepository.java
+++ b/src/main/java/com/BeatUp/BackEnd/RideRequest/repository/RideRequestRepository.java
@@ -4,7 +4,6 @@ package com.BeatUp.BackEnd.RideRequest.repository;
 import com.BeatUp.BackEnd.RideRequest.entity.RideRequest;
 import com.BeatUp.BackEnd.common.repository.StatusRepository;
 import com.BeatUp.BackEnd.common.repository.UserOwnedRepository;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/BeatUp/BackEnd/User/controller/AuthController.java
+++ b/src/main/java/com/BeatUp/BackEnd/User/controller/AuthController.java
@@ -3,7 +3,6 @@ package com.BeatUp.BackEnd.User.controller;
 
 import com.BeatUp.BackEnd.User.entity.UserAccount;
 import com.BeatUp.BackEnd.User.entity.UserProfile;
-import com.BeatUp.BackEnd.User.repository.UserAccountRepository;
 import com.BeatUp.BackEnd.User.repository.UserProfileRepository;
 import com.BeatUp.BackEnd.User.service.FirebaseAuthService;
 import com.google.firebase.auth.FirebaseAuthException;
@@ -22,14 +21,11 @@ public class AuthController {
 
     private final FirebaseAuthService firebaseAuthService;
     private final UserProfileRepository userProfileRepository;
-    private final UserAccountRepository userAccountRepository;
 
     public AuthController(FirebaseAuthService firebaseAuthService,
-                          UserProfileRepository userProfileRepository,
-                          UserAccountRepository userAccountRepository){
+                          UserProfileRepository userProfileRepository){
         this.firebaseAuthService = firebaseAuthService;
         this.userProfileRepository = userProfileRepository;
-        this.userAccountRepository = userAccountRepository;
     }
 
     /**

--- a/src/main/java/com/BeatUp/BackEnd/User/controller/ProfileController.java
+++ b/src/main/java/com/BeatUp/BackEnd/User/controller/ProfileController.java
@@ -9,7 +9,6 @@ import com.BeatUp.BackEnd.common.util.SecurityUtil;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;

--- a/src/main/java/com/BeatUp/BackEnd/User/entity/UserAccount.java
+++ b/src/main/java/com/BeatUp/BackEnd/User/entity/UserAccount.java
@@ -5,10 +5,6 @@ import com.BeatUp.BackEnd.common.entity.BaseEntity;
 import com.BeatUp.BackEnd.common.enums.AuthProvider;
 import jakarta.persistence.*;
 import lombok.Getter;
-import org.hibernate.annotations.CreationTimestamp;
-
-import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Entity
 @Getter

--- a/src/main/java/com/BeatUp/BackEnd/User/repository/UserAccountRepository.java
+++ b/src/main/java/com/BeatUp/BackEnd/User/repository/UserAccountRepository.java
@@ -6,7 +6,6 @@ import com.BeatUp.BackEnd.common.repository.BaseRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
-import java.util.UUID;
 
 @Repository
 public interface UserAccountRepository extends BaseRepository<UserAccount> {

--- a/src/main/java/com/BeatUp/BackEnd/WebSocket/WebSocketController.java
+++ b/src/main/java/com/BeatUp/BackEnd/WebSocket/WebSocketController.java
@@ -3,9 +3,7 @@ package com.BeatUp.BackEnd.WebSocket;
 
 import com.BeatUp.BackEnd.Chat.ChatMessage.dto.request.ChatMessageRequest;
 import com.BeatUp.BackEnd.Chat.ChatMessage.dto.response.ChatMessageResponse;
-import com.BeatUp.BackEnd.Chat.ChatMessage.repository.ChatMessageRepository;
 import com.BeatUp.BackEnd.Chat.ChatMessage.service.ChatMessageService;
-import com.BeatUp.BackEnd.User.repository.UserProfileRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -20,12 +18,6 @@ import java.util.UUID;
 
 @Controller
 public class WebSocketController {
-
-    @Autowired
-    private ChatMessageRepository chatMessageRepository;
-
-    @Autowired
-    private UserProfileRepository userProfileRepository;
 
     @Autowired
     private ChatMessageService chatMessageService;

--- a/src/main/java/com/BeatUp/BackEnd/common/config/SecurityConfig.java
+++ b/src/main/java/com/BeatUp/BackEnd/common/config/SecurityConfig.java
@@ -2,11 +2,9 @@ package com.BeatUp.BackEnd.common.config;
 
 
 import com.BeatUp.BackEnd.User.filter.FirebaseAuthenticationFilter;
-import com.BeatUp.BackEnd.User.filter.JwtAuthenticationFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;

--- a/src/test/java/com/BeatUp/BackEnd/KAKAOAPI/CategoryMapperTest.java
+++ b/src/test/java/com/BeatUp/BackEnd/KAKAOAPI/CategoryMapperTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 

--- a/src/test/java/com/BeatUp/BackEnd/Places/PlacesControllerTest.java
+++ b/src/test/java/com/BeatUp/BackEnd/Places/PlacesControllerTest.java
@@ -1,0 +1,91 @@
+package com.BeatUp.BackEnd.Places;
+
+import com.BeatUp.BackEnd.Places.Mapper.CategoryMapper;
+import com.BeatUp.BackEnd.Places.controller.PlacesController;
+import com.BeatUp.BackEnd.Places.dto.request.NearbySearchRequest;
+import com.BeatUp.BackEnd.Places.dto.response.*;
+import com.BeatUp.BackEnd.Places.service.PlaceService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PlacesControllerTest {
+
+    @Mock
+    private PlaceService placeService;
+
+    @Mock
+    private CategoryMapper categoryMapper;
+
+    @InjectMocks
+    private PlacesController placesController;
+
+    @Test
+    @DisplayName("주변 장소 검색 성공")
+    void getNearbyPlaces_Success() {
+        // Given
+        NearbySearchResponse mockResponse = createMockResponse();
+        when(placeService.searchNearby(any(NearbySearchRequest.class)))
+                .thenReturn(mockResponse);
+        when(categoryMapper.isValidCategory("카페")).thenReturn(true);
+
+        // When
+        ResponseEntity<NearbySearchResponse> response = placesController.getNearbyPlaces(
+                37.5665, 126.9780, 1000, List.of("카페"), null, 20, 0);
+
+        // Then
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(1, response.getBody().getTotalCount());
+        assertEquals("테스트 카페", response.getBody().getPlaces().get(0).getName());
+    }
+
+    @Test
+    @DisplayName("카테고리 목록 조회")
+    void getSupportedCategories_Success() {
+        // When
+        ResponseEntity<Map<String, Object>> response = placesController.getSupportedCategories();
+
+        // Then
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().containsKey("categories"));
+    }
+
+    private NearbySearchResponse createMockResponse() {
+        PlaceResponse place = PlaceResponse.builder()
+                .id("12345")
+                .name("테스트 카페")
+                .address("서울 강남구 테헤란로 123")
+                .category(CategoryResponse.builder()
+                        .name("카페")
+                        .code("CE7")
+                        .build())
+                .location(LocationResponse.of(37.5665, 126.9780))
+                .distance(DistanceResponse.builder()
+                        .meters(300)
+                        .displayText("내 위치에서 300m")
+                        .build())
+                .build();
+
+        return NearbySearchResponse.builder()
+                .places(List.of(place))
+                .totalCount(1)
+                .searchCenter(LocationResponse.of(37.5665, 126.9780))
+                .cacheHit(false)
+                .build();
+    }
+}

--- a/src/test/java/com/BeatUp/BackEnd/Places/PlacesServiceTest.java
+++ b/src/test/java/com/BeatUp/BackEnd/Places/PlacesServiceTest.java
@@ -12,10 +12,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
## 연관 이슈
> Closes #41 

## 개요 
> PlaceService를 Restful API로 노출하는 컨트롤러 구현

## 변경사항
### PlacesController 구현
- 주변 장소 검색: GET/places/nearby - 위경도 기반 장소 검색
- 카테고리 목록: GET/places/categories - 지원 카테고리 조회
- 검증 적용: @Valid 검증
- 카테고리 필터링: 유효하지 않은 것들 제거

### PlacesControllerTest 구현
- Mock 기반 테스트