### PR TITLE
[FEAT] 매칭 성공시 채팅방 생성 및 자동 초대 기능 구현

### DIFF
--- a/src/main/java/com/BeatUp/BackEnd/RideRequest/dto/response/RideRequestResponse.java
+++ b/src/main/java/com/BeatUp/BackEnd/RideRequest/dto/response/RideRequestResponse.java
@@ -13,6 +13,7 @@ public class RideRequestResponse {
     private String status;
     private UUID matchGroupId;
     private LocalDateTime createdAt;
+    private UUID roomId;
 
     // 기본 생성자
     public RideRequestResponse() {}
@@ -55,4 +56,7 @@ public class RideRequestResponse {
 
     public LocalDateTime getCreatedAt() { return createdAt; }
     public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+
+    public UUID getRoomId(){return roomId;}
+    public void setRoomId(UUID roomId){this.roomId = roomId;}
 }


### PR DESCRIPTION
## 연관 이슈
> Closes #15 

## Description
> 매칭 성공 시 자동으로 채팅방을 생성하고, 매칭된 모든 사용자를 채팅방에 자동으로 초대하는 기능을 구현

## 변경 사항
1. MatchingScheduler 수정
- createMatchGroup 메서드에 채팅방 자동 생성 로직 추가
- 매칭 그룹 생성 후 createMatchRoom 메서드 호출 
- 매칭된 모든 사용자를 채팅방에 자동 초대

2. 새로운 의존성 추가
- ChatRoomService
- ChatMessageRepository
- ChatMemberRepository 제거

3. 채팅방 생성 로직
- 매칭 그룹 ID를 subjectId로 하는 MATCH 타입 채팅방 생성
- 첫 번째 사용자를 채팅방 생성자로 설정
- 나머지 사용자들을 자동으로 채팅방에 초대
- 매칭 완료 시스템 메시지 추가