### PR TITLE
[FEAT] 매칭 성공 시 택시/라이드 서비스 가격 비교 기능 구현

### DIFF
--- a/src/main/java/com/BeatUp/BackEnd/Chat/ChatMessage/service/ChatMessageService.java
+++ b/src/main/java/com/BeatUp/BackEnd/Chat/ChatMessage/service/ChatMessageService.java
@@ -9,6 +9,8 @@ import com.BeatUp.BackEnd.Chat.ChatRoom.entity.ChatMember;
 import com.BeatUp.BackEnd.Chat.ChatRoom.entity.ChatRoom;
 import com.BeatUp.BackEnd.Chat.ChatRoom.repository.ChatMemberRepsoitory;
 import com.BeatUp.BackEnd.Chat.ChatRoom.repository.ChatRoomRepository;
+import com.BeatUp.BackEnd.Match.taxi.dto.response.TaxiServiceResponse;
+import com.BeatUp.BackEnd.Match.taxi.service.TaxiComparisonService;
 import com.BeatUp.BackEnd.User.repository.UserProfileRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
@@ -34,6 +36,9 @@ public class ChatMessageService {
 
     @Autowired
     private ChatMessageRepository chatMessageRepository;
+
+    @Autowired
+    private TaxiComparisonService taxiComparisonService;
 
     @Autowired
     private UserProfileRepository userProfileRepository;
@@ -129,6 +134,15 @@ public class ChatMessageService {
                 sendSystemMessage(roomId, " 이 명령어는 매칭 채팅방에서만 사용할 수 있습니다.");
                 return;
             }
+
+            // 매칭 그룹 ID로 택시 서비스 비교
+            UUID matchGroupId = chatRoom.getSubjectId();
+            List<TaxiServiceResponse> taxiOptions = taxiComparisonService.compareService(matchGroupId);
+            
+            // 택시 가격 비교 메시지 포맷팅 및 전송
+            String taxiMessage = taxiComparisonService.formatTaxiMessage(taxiOptions);
+            sendSystemMessage(roomId, taxiMessage);
+            
         }catch(Exception e){
             sendSystemMessage(roomId, " 택시 정보를 가져오는 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
             System.err.println("택시 명령어 처리 오류: " + e.getMessage());

--- a/src/main/java/com/BeatUp/BackEnd/Concert/entity/Concert.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/entity/Concert.java
@@ -77,6 +77,13 @@ public class Concert extends BaseEntity {
     @Column(name = "age_limit", length = 50)
     private String ageLimit;
 
+    // 공연장 좌표 정보
+    @Column(name = "venue_lat")
+    private Double venueLat; // 공연장 위도
+
+    @Column(name = "venue_lng")
+    private Double venueLng; // 공연장 경도
+
     @Column(columnDefinition = "TEXT")
     private String synopsis;
 

--- a/src/main/java/com/BeatUp/BackEnd/Concert/repository/ConcertRepository.java
+++ b/src/main/java/com/BeatUp/BackEnd/Concert/repository/ConcertRepository.java
@@ -56,4 +56,7 @@ public interface ConcertRepository extends JpaRepository<Concert, UUID>, Concert
 
     @Query("SELECT c.area, COUNT(c) FROM Concert c WHERE c.area IS NOT NULL GROUP BY c.area ORDER BY COUNT(c) DESC")
     List<Object[]> countByArea();
+
+    // 좌표가 없는 공연 조회
+    List<Concert> findByVenueLatIsNullAndVenueLngIsNull();
 }

--- a/src/main/java/com/BeatUp/BackEnd/Match/scheduler/MatchingScheduler.java
+++ b/src/main/java/com/BeatUp/BackEnd/Match/scheduler/MatchingScheduler.java
@@ -197,7 +197,8 @@ public class MatchingScheduler {
             // 3. 매칭 완료 시스템 메시지 추가
             ChatMessage matchCompleteMessage = new ChatMessage(
                     roomResponse.getId(),
-                    "동승 매칭이 완료되었습니다!"
+                    "동승 매칭이 완료되었습니다!\n\n" +
+                    "`/택시` 명령어로 가격 비교해보세요!"
             );
             chatMessageRepository.save(matchCompleteMessage);
 

--- a/src/main/java/com/BeatUp/BackEnd/Match/scheduler/MatchingScheduler.java
+++ b/src/main/java/com/BeatUp/BackEnd/Match/scheduler/MatchingScheduler.java
@@ -202,6 +202,7 @@ public class MatchingScheduler {
             chatMessageRepository.save(matchCompleteMessage);
 
             System.out.println("채팅방 자동 생성 완료: " + roomResponse.getId());
+
         } catch (Exception e) {
             System.out.println("채팅방 생성 실패: " + e.getMessage());
         }

--- a/src/main/java/com/BeatUp/BackEnd/Match/taxi/dto/response/TaxiServiceResponse.java
+++ b/src/main/java/com/BeatUp/BackEnd/Match/taxi/dto/response/TaxiServiceResponse.java
@@ -1,0 +1,39 @@
+package com.BeatUp.BackEnd.Match.taxi.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class TaxiServiceResponse {
+    private String serviceName; // "카카오T", "우버", "타다"
+    private Integer estimatePrice; // 예상요금
+    private Integer estimatedTime; // 예상 소요시간(분)
+    private String deeplink; // 예약 딥링크
+    private String weblink; // 웹 예약 링크
+    private List<String> discounts; // 적용 가능한 할인
+
+    // 기본 생성자
+    public TaxiServiceResponse() {
+    }
+
+    // 모든 필드를 포함한 생성자
+    public TaxiServiceResponse(String serviceName, Integer estimatePrice, Integer estimatedTime, 
+                              String deeplink, String weblink, List<String> discounts) {
+        this.serviceName = serviceName;
+        this.estimatePrice = estimatePrice;
+        this.estimatedTime = estimatedTime;
+        this.deeplink = deeplink;
+        this.weblink = weblink;
+        this.discounts = discounts;
+    }
+
+    // 필수 필드만 포함한 생성자 (편의용)
+    public TaxiServiceResponse(String serviceName, Integer estimatePrice, Integer estimatedTime) {
+        this.serviceName = serviceName;
+        this.estimatePrice = estimatePrice;
+        this.estimatedTime = estimatedTime;
+    }
+}

--- a/src/main/java/com/BeatUp/BackEnd/Match/taxi/service/TaxiComparisonService.java
+++ b/src/main/java/com/BeatUp/BackEnd/Match/taxi/service/TaxiComparisonService.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
@@ -94,5 +95,30 @@ public class TaxiComparisonService {
     private TaxiServiceResponse getTadaPrice(double pickupLat, double pickupLng, double destLat, double destLng) {
         // 타다 API 호출 로직
         return new TaxiServiceResponse("타다", 9000, 18);
+    }
+
+    public String formatTaxiMessage(List<TaxiServiceResponse> options){
+        if(options.isEmpty()){
+            return "택시 서비스 정보를 가져올 수 없습니다. 잠시 후 다시 시도해주세요.";
+        }
+
+        StringBuilder message = new StringBuilder("택시 서비스 가격 비교\n");
+
+        // 거리 순으로 정렬
+        options.sort(Comparator.comparing(TaxiServiceResponse::getEstimatePrice));
+
+        for(int i = 0; i < options.size(); i++){
+            TaxiServiceResponse option = options.get(i);
+
+            message.append(String.format("%s **%s**; %,d원 (%d분)\n",
+                    option.getServiceName(),
+                    option.getEstimatePrice(),
+                    option.getEstimatedTime()));
+        }
+
+        message.append("\n 원하는 서비스를 선택하시면 예약 페이지로 이동합니다.");
+        message.append("\n🔄 다시 조회하려면 `/택시` 명령어를 사용하세요.");
+
+        return message.toString();
     }
 }

--- a/src/main/java/com/BeatUp/BackEnd/Match/taxi/service/TaxiComparisonService.java
+++ b/src/main/java/com/BeatUp/BackEnd/Match/taxi/service/TaxiComparisonService.java
@@ -1,0 +1,98 @@
+package com.BeatUp.BackEnd.Match.taxi.service;
+
+
+import com.BeatUp.BackEnd.Concert.entity.Concert;
+import com.BeatUp.BackEnd.Concert.repository.ConcertRepository;
+import com.BeatUp.BackEnd.Match.entity.MatchGroup;
+import com.BeatUp.BackEnd.Match.repository.MatchGroupRepository;
+import com.BeatUp.BackEnd.Match.taxi.dto.response.TaxiServiceResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class TaxiComparisonService {
+
+    @Autowired
+    private MatchGroupRepository matchGroupRepository;
+
+    @Autowired
+    private ConcertRepository concertRepository;
+
+    public List<TaxiServiceResponse> compareService(UUID matchGroupId){
+        // 1. 매칭 그룹 정보 조회
+        MatchGroup matchGroup = matchGroupRepository.findById(matchGroupId)
+                .orElseThrow(() -> new IllegalArgumentException("매칭 그룹을 찾을 수 없습니다."));
+
+        // 2. 공연장 정보 조회
+        Concert concert = concertRepository.findById(matchGroup.getConcertId())
+                .orElseThrow(() -> new IllegalArgumentException("공연장을 찾을 수 없습니다."));
+
+        // 3. 목적지 좌표 파싱 (destBucket에서)
+        String[] coords = matchGroup.getDestBucket().split(",");
+        double destLat = Double.parseDouble(coords[0]);
+        double destLng = Double.parseDouble(coords[1]);
+
+        // 4. 출발지 좌표 설정 (공연장 좌표 사용)
+        double pickupLat, pickupLng;
+        
+        if (concert.getVenueLat() != null && concert.getVenueLng() != null) {
+            // DB에 저장된 공연장 좌표 사용
+            pickupLat = concert.getVenueLat();
+            pickupLng = concert.getVenueLng();
+        } else {
+            // 좌표가 없는 경우 기본값 사용 (서울 중심가)
+            pickupLat = 37.5665;
+            pickupLng = 126.9780;
+            System.out.println("공연장 좌표가 없어 기본값 사용 - venue: " + concert.getVenue());
+        }
+
+        // 5. 각 서비스별 요금 조회
+        List<TaxiServiceResponse> responses = new ArrayList<>();
+
+        // 카카오T 요금 조회
+        try{
+            TaxiServiceResponse kakaoT = getKakaoTPrice(pickupLat, pickupLng, destLat, destLng);
+            responses.add(kakaoT);
+        } catch (Exception e) {
+            System.err.println("카카오T 요금 조회 실패: " + e.getMessage());
+        }
+
+        // 우버 요금 조회
+        try{
+            TaxiServiceResponse uber = getUberPrice(pickupLat, pickupLng, destLat, destLng);
+            responses.add(uber);
+        } catch (Exception e) {
+            System.err.println("우버 요금 조회 실패: " + e.getMessage());
+        }
+
+        // 타다 요금 조회
+        try{
+            TaxiServiceResponse tada = getTadaPrice(pickupLat, pickupLng, destLat, destLng);
+            responses.add(tada);
+        } catch (Exception e) {
+            System.err.println("타다 요금 조회 실패: " + e.getMessage());
+        }
+
+        return responses;
+    }
+
+    private TaxiServiceResponse getKakaoTPrice(double pickupLat, double pickupLng, double destLat, double destLng){
+        // 카카오 API 호출 로직
+        // 실제 구현시 카카오 모빌리티 API 사용
+        return new TaxiServiceResponse("카카오T", 8000, 15);
+    }
+
+    private TaxiServiceResponse getUberPrice(double pickupLat, double pickupLng, double destLat, double destLng) {
+        // 우버 API 호출 로직
+        return new TaxiServiceResponse("우버", 7500, 12);
+    }
+
+    private TaxiServiceResponse getTadaPrice(double pickupLat, double pickupLng, double destLat, double destLng) {
+        // 타다 API 호출 로직
+        return new TaxiServiceResponse("타다", 9000, 18);
+    }
+}

--- a/src/main/java/com/BeatUp/BackEnd/Match/taxi/service/TaxiComparisonService.java
+++ b/src/main/java/com/BeatUp/BackEnd/Match/taxi/service/TaxiComparisonService.java
@@ -6,9 +6,13 @@ import com.BeatUp.BackEnd.Concert.repository.ConcertRepository;
 import com.BeatUp.BackEnd.Match.entity.MatchGroup;
 import com.BeatUp.BackEnd.Match.repository.MatchGroupRepository;
 import com.BeatUp.BackEnd.Match.taxi.dto.response.TaxiServiceResponse;
+import com.BeatUp.BackEnd.common.util.GeoUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -22,6 +26,7 @@ public class TaxiComparisonService {
 
     @Autowired
     private ConcertRepository concertRepository;
+
 
     public List<TaxiServiceResponse> compareService(UUID matchGroupId){
         // 1. 매칭 그룹 정보 조회
@@ -82,19 +87,113 @@ public class TaxiComparisonService {
     }
 
     private TaxiServiceResponse getKakaoTPrice(double pickupLat, double pickupLng, double destLat, double destLng){
-        // 카카오 API 호출 로직
-        // 실제 구현시 카카오 모빌리티 API 사용
-        return new TaxiServiceResponse("카카오T", 8000, 15);
+        // 거리 계산(Harvesine 공식)
+        double distance = GeoUtils.calculateDistance(pickupLat, pickupLng, destLat, destLng); // km
+        int estimatedTime = GeoUtils.calculateEstimateTime(distance);
+
+        // 기본 요금 계산
+        int baseFare = 3800; // 기본요금(2km까지)
+        int distanceFare = 0;
+
+        if(distance > 2.0){
+            distanceFare = (int)Math.ceil((distance - 2.0) / 0.142) * 100; // 100원/142m
+        }
+
+        // 시간 요금 (정차 시간 추정)
+        int timeFare = (int) Math.ceil(estimatedTime * 0.3) * 100; // 35초당 100원, 정차시간 30% 추정
+
+        // 할증 계산
+        double surcharge = 1.0;
+        LocalTime now = LocalTime.now();
+        if(now.isAfter(LocalTime.of(23, 0)) || now.isBefore(LocalTime.of(4, 0))){
+            surcharge += 0.2; // 심야할증 20%
+        }
+        if(distance > 10.0){
+            surcharge += 0.2; // 거리할증 20%
+        }
+
+        int totalFare = (int) Math.round((baseFare + distanceFare + timeFare) * surcharge);
+
+        return new TaxiServiceResponse("카카오T", totalFare, estimatedTime);
     }
 
     private TaxiServiceResponse getUberPrice(double pickupLat, double pickupLng, double destLat, double destLng) {
-        // 우버 API 호출 로직
-        return new TaxiServiceResponse("우버", 7500, 12);
+        double distance = GeoUtils.calculateDistance(pickupLat, pickupLng, destLat, destLng);
+        int estimatedTime = GeoUtils.calculateEstimateTime(distance);
+
+        // UberX 기준
+        int baseFare = 2500;
+        int distanceFare = (int) Math.round(distance * 200); // 200원/km
+        int timeFare = estimatedTime * 100;
+
+        // 수요 할증 (시간대별, 지역별)
+        double surgeMultiplier = calculateSurgeMultiplier(pickupLat, pickupLng);
+
+        int totalFare = (int) Math.round((baseFare + distanceFare + timeFare) * surgeMultiplier);
+        totalFare = Math.max(3500, totalFare); // 최소요금 3500원
+        return new TaxiServiceResponse("우버", totalFare, estimatedTime);
+    }
+
+    private double calculateSurgeMultiplier(double lat, double lng){
+        // 간단한 수요할증 계산
+        LocalTime now  = LocalTime.now();
+        double baseMultliplier = 1.0;
+
+        // 출퇴근 시간 할증
+        if((now.isAfter(LocalTime.of(7, 0)) && now.isBefore(LocalTime.of(9,0))) ||
+                (now.isAfter(LocalTime.of(18,0)) && now.isBefore(LocalTime.of(20, 0)))){
+            baseMultliplier += 0.5;
+        }
+
+        // 주말 할증
+        if(LocalDate.now().getDayOfWeek() == DayOfWeek.SATURDAY ||
+            LocalDate.now().getDayOfWeek() == DayOfWeek.SUNDAY){
+            baseMultliplier += 0.3;
+        }
+
+        return Math.min(3.0, baseMultliplier); // 최대 3배
     }
 
     private TaxiServiceResponse getTadaPrice(double pickupLat, double pickupLng, double destLat, double destLng) {
-        // 타다 API 호출 로직
-        return new TaxiServiceResponse("타다", 9000, 18);
+        double distance = GeoUtils.calculateDistance(pickupLat, pickupLng, destLat, destLng);
+        int estimatedTime = GeoUtils.calculateEstimateTime(distance);
+
+        // 타다 일반 기준
+        int baseFare = 4000; // 3km까지
+        int distanceFare = 0;
+
+        if (distance > 3.0) {
+            distanceFare = (int) Math.round((distance - 3.0) * 200); // 200원/km
+        }
+
+        int timeFare = estimatedTime * 100; // 100원/분
+
+        // 수요할증
+        double surgeMultiplier = calculateTadaSurgeMultiplier(pickupLat, pickupLng);
+
+        int totalFare = (int) Math.round((baseFare + distanceFare + timeFare) * surgeMultiplier);
+        totalFare = Math.max(5000, totalFare); // 최소요금 5,000원
+
+        return new TaxiServiceResponse("타다", totalFare, estimatedTime);
+    }
+
+    private double calculateTadaSurgeMultiplier(double lat, double lng) {
+        // 타다 수요할증 계산
+        LocalTime now = LocalTime.now();
+        double baseMultiplier = 1.0;
+
+        // 심야 할증
+        if (now.isAfter(LocalTime.of(22, 0)) || now.isBefore(LocalTime.of(6, 0))) {
+            baseMultiplier += 0.3;
+        }
+
+        // 출퇴근 시간 할증
+        if ((now.isAfter(LocalTime.of(7, 0)) && now.isBefore(LocalTime.of(9, 0))) ||
+                (now.isAfter(LocalTime.of(17, 0)) && now.isBefore(LocalTime.of(19, 0)))) {
+            baseMultiplier += 0.4;
+        }
+
+        return Math.min(2.5, baseMultiplier); // 최대 2.5배
     }
 
     public String formatTaxiMessage(List<TaxiServiceResponse> options){

--- a/src/main/java/com/BeatUp/BackEnd/Places/service/PlaceService.java
+++ b/src/main/java/com/BeatUp/BackEnd/Places/service/PlaceService.java
@@ -197,4 +197,41 @@ public class PlaceService {
         }
         return phone.trim().replaceAll("\\s+", " ");
     }
+
+    /**
+     * 공연장명으로 좌표 조회
+     */
+    public LocationResponse searchVenueCoordinates(String venueName) {
+        if (venueName == null || venueName.trim().isEmpty()) {
+            log.warn("공연장명이 비어있습니다.");
+            return null;
+        }
+
+        try {
+            log.debug("공연장 좌표 조회 시작 - venue: {}", venueName);
+            
+            // 카카오 Places API로 키워드 검색
+            KakaoPlaceSearchResponse response = kakaoClient.searchByKeyword(venueName, 1);
+            
+            if (response != null && response.getDocuments() != null && !response.getDocuments().isEmpty()) {
+                KakaoPlaceSearchResponse.PlaceDocument place = response.getDocuments().get(0);
+                
+                double lat = Double.parseDouble(place.getY());
+                double lng = Double.parseDouble(place.getX());
+                
+                log.info("공연장 좌표 조회 성공 - venue: {}, lat: {}, lng: {}", venueName, lat, lng);
+                
+                return LocationResponse.builder()
+                        .lat(lat)
+                        .lng(lng)
+                        .build();
+            } else {
+                log.warn("공연장 좌표를 찾을 수 없습니다 - venue: {}", venueName);
+                return null;
+            }
+        } catch (Exception e) {
+            log.error("공연장 좌표 조회 실패 - venue: {}, error: {}", venueName, e.getMessage());
+            return null;
+        }
+    }
 }

--- a/src/main/java/com/BeatUp/BackEnd/WebSocket/WebSocketController.java
+++ b/src/main/java/com/BeatUp/BackEnd/WebSocket/WebSocketController.java
@@ -46,11 +46,17 @@ public class WebSocketController {
 
             System.out.println("메시지 처리 - 방: " + roomId + ", 발신자:" + senderId);
 
-            // 3. ChatService를 통해 메시지 저장 및 검증
+            // 3. 슬래시 명령어 처리
+            if (content.startsWith("/")) {
+                chatMessageService.handleSlashCommand(senderId, roomId, content.trim());
+                return; // 슬래시 명령어는 일반 메시지로 저장하지 않음
+            }
+
+            // 4. ChatService를 통해 메시지 저장 및 검증
             ChatMessageRequest request = new ChatMessageRequest(content.trim());
             ChatMessageResponse response = chatMessageService.sendMessage(roomId, senderId, request);
 
-            // 4. 채팅방의 모든 구독자에게 브로드캐스트
+            // 5. 채팅방의 모든 구독자에게 브로드캐스트
             messagingTemplate.convertAndSend("/topic/rooms/" + roomId, response);
 
             System.out.println("메시지 브로드캐스트 완료 - " + response.getSenderName());

--- a/src/main/java/com/BeatUp/BackEnd/common/util/GeoUtils.java
+++ b/src/main/java/com/BeatUp/BackEnd/common/util/GeoUtils.java
@@ -1,0 +1,28 @@
+package com.BeatUp.BackEnd.common.util;
+
+
+
+public class GeoUtils {
+
+    // Harvesine 공식으로 거리 계산(km)
+    public static double calculateDistance(double lat1, double lng1, double lat2, double lng2){
+        final int R = 6371; // 지구 반지름(km)
+
+        double latDistance = Math.toRadians(lat2 - lat1);
+        double lngDistance = Math.toRadians(lng2 - lng1);
+
+        double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                + Math.sin(lngDistance / 2) * Math.sin(lngDistance / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return R * c;
+    }
+
+    // 예상 소요시간 계산(분)
+    public static int calculateEstimateTime(double distance){
+        // 평균 속도 30km/h로 계산(도심지 기준)
+        return (int) Math.round(distance / 30.0 * 60);
+    }
+}


### PR DESCRIPTION
## 연관이슈
> Closes #49 

## 구현 내용

#### 1. 택시 서비스 가격 비교 시스템
- TaxiComparisonService: 각 택시 서비스별 요금 계산 로직
   - 카카오 T: 기본 요금 3000원, 거리/시간 요금, 심야/거리할증 적용
   - 우버: UberX 기준, 수요할증 시스템 적용
   - 타다: 일반 서비스 기준, 시간대별 할증 적용

#### 2. 지리적 계산 유틸리티
- GeoUtils : Harvesine 공식으로 정확한 거리 계산
- 평균 속도 30km/h 기준 예상 소요시간 계산

#### 3. 채팅 명령어 시스템
- ChatMessageService: `/택시`, `/taxi`, `/가격`, `/요금` 명령어
- 매칭 채팅방에서만 사용 가능
- 실시간 가격 비교 결과를 채팅으로 표시

#### 4. 매칭 완료 시 자동 안내
- MatchingScheduler: 매칭 성공 시 택시 가격 비교 명령어 안내 메시지 자동 전송

## 구현
- 요금 계산: 각 서비스별 실제 요금 구조 적용
- 할증 시스템: 시간대, 거리, 수요에 따른 할증
- 에러 처리: 각 서비스별 에러 처리
- 메시지 포맷팅: 가격 순 정렬 

## 사용법
1. 매칭 완료 후  `/택시` 명령어 입력
2. 카카오 T, 우버, 타다 가격 비교
3. 원하는 서비스 선택

## etc
- 각 서비스별 딥링크 방식으로 앱으로 이동시키기