### PR TITLE
test: 택시/라이드 서비스 가격 비교 테스트 코드 작성

### DIFF
--- a/src/main/java/com/BeatUp/BackEnd/Chat/ChatRoom/entity/ChatRoom.java
+++ b/src/main/java/com/BeatUp/BackEnd/Chat/ChatRoom/entity/ChatRoom.java
@@ -34,7 +34,7 @@ public class ChatRoom extends BaseEntity {
     private UUID createdBy; // 방 생성자 ID
 
     // 생성자
-    protected ChatRoom(){}
+    public ChatRoom(){}
 
     public ChatRoom(String type, UUID subjectId, String title, UUID createdBy){
         this.type = type;

--- a/src/main/java/com/BeatUp/BackEnd/Match/entity/MatchGroup.java
+++ b/src/main/java/com/BeatUp/BackEnd/Match/entity/MatchGroup.java
@@ -4,11 +4,13 @@ package com.BeatUp.BackEnd.Match.entity;
 import com.BeatUp.BackEnd.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.UUID;
 
 @Entity
 @Getter
+@Setter
 @Table(name = "match_group")
 public class MatchGroup extends BaseEntity {
 
@@ -27,7 +29,7 @@ public class MatchGroup extends BaseEntity {
     private String status = "OPEN";
 
     // 기본 생성자
-    protected MatchGroup(){}
+    public MatchGroup(){}
 
     // 생성자
     public MatchGroup(UUID concertId, String direction, String destBucket){
@@ -46,4 +48,5 @@ public class MatchGroup extends BaseEntity {
         return "MatchGroupId=" + getId() + ", concertId=" + concertId +
                 ", direction= " + direction + ",bucket=" + destBucket + "}";
     }
+
 }

--- a/src/main/java/com/BeatUp/BackEnd/Match/taxi/service/TaxiComparisonService.java
+++ b/src/main/java/com/BeatUp/BackEnd/Match/taxi/service/TaxiComparisonService.java
@@ -86,7 +86,7 @@ public class TaxiComparisonService {
         return responses;
     }
 
-    private TaxiServiceResponse getKakaoTPrice(double pickupLat, double pickupLng, double destLat, double destLng){
+    public TaxiServiceResponse getKakaoTPrice(double pickupLat, double pickupLng, double destLat, double destLng){
         // 거리 계산(Harvesine 공식)
         double distance = GeoUtils.calculateDistance(pickupLat, pickupLng, destLat, destLng); // km
         int estimatedTime = GeoUtils.calculateEstimateTime(distance);
@@ -117,7 +117,7 @@ public class TaxiComparisonService {
         return new TaxiServiceResponse("카카오T", totalFare, estimatedTime);
     }
 
-    private TaxiServiceResponse getUberPrice(double pickupLat, double pickupLng, double destLat, double destLng) {
+    public TaxiServiceResponse getUberPrice(double pickupLat, double pickupLng, double destLat, double destLng) {
         double distance = GeoUtils.calculateDistance(pickupLat, pickupLng, destLat, destLng);
         int estimatedTime = GeoUtils.calculateEstimateTime(distance);
 
@@ -154,7 +154,7 @@ public class TaxiComparisonService {
         return Math.min(3.0, baseMultliplier); // 최대 3배
     }
 
-    private TaxiServiceResponse getTadaPrice(double pickupLat, double pickupLng, double destLat, double destLng) {
+    public TaxiServiceResponse getTadaPrice(double pickupLat, double pickupLng, double destLat, double destLng) {
         double distance = GeoUtils.calculateDistance(pickupLat, pickupLng, destLat, destLng);
         int estimatedTime = GeoUtils.calculateEstimateTime(distance);
 
@@ -209,7 +209,7 @@ public class TaxiComparisonService {
         for(int i = 0; i < options.size(); i++){
             TaxiServiceResponse option = options.get(i);
 
-            message.append(String.format("%s **%s**; %,d원 (%d분)\n",
+            message.append(String.format("%s **%,d원** (%d분)\n",
                     option.getServiceName(),
                     option.getEstimatePrice(),
                     option.getEstimatedTime()));

--- a/src/main/java/com/BeatUp/BackEnd/common/entity/BaseEntity.java
+++ b/src/main/java/com/BeatUp/BackEnd/common/entity/BaseEntity.java
@@ -3,6 +3,7 @@ package com.BeatUp.BackEnd.common.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -14,6 +15,7 @@ import java.util.UUID;
  * 모든 엔티티의 기본 클래스
  */
 @Getter
+@Setter
 @MappedSuperclass
 public abstract class BaseEntity {
 

--- a/src/main/java/com/BeatUp/BackEnd/common/util/GeoUtils.java
+++ b/src/main/java/com/BeatUp/BackEnd/common/util/GeoUtils.java
@@ -13,7 +13,7 @@ public class GeoUtils {
 
         double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2)
                 + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
-                + Math.sin(lngDistance / 2) * Math.sin(lngDistance / 2);
+                * Math.sin(lngDistance / 2) * Math.sin(lngDistance / 2);
 
         double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 

--- a/src/test/java/com/BeatUp/BackEnd/Chat/ChatMessage/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/BeatUp/BackEnd/Chat/ChatMessage/service/ChatMessageServiceTest.java
@@ -1,0 +1,179 @@
+package com.BeatUp.BackEnd.Chat.ChatMessage.service;
+
+import com.BeatUp.BackEnd.Chat.ChatMessage.entity.ChatMessage;
+import com.BeatUp.BackEnd.Chat.ChatMessage.repository.ChatMessageRepository;
+import com.BeatUp.BackEnd.Chat.ChatRoom.entity.ChatRoom;
+import com.BeatUp.BackEnd.Chat.ChatRoom.repository.ChatRoomRepository;
+import com.BeatUp.BackEnd.Match.taxi.dto.response.TaxiServiceResponse;
+import com.BeatUp.BackEnd.Match.taxi.service.TaxiComparisonService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageServiceTest {
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+
+    @Mock
+    private TaxiComparisonService taxiComparisonService;
+
+    @InjectMocks
+    private ChatMessageService chatMessageService;
+
+    private ChatRoom matchChatRoom;
+    private ChatRoom normalChatRoom;
+
+    @BeforeEach
+    void setUp() {
+        // 매칭 채팅방 설정
+        UUID matchGroupId = UUID.randomUUID();
+        UUID creatorId = UUID.randomUUID();
+        matchChatRoom = new ChatRoom("MATCH", matchGroupId, "동승 매칭 그룹", creatorId);
+
+        // 일반 채팅방 설정
+        UUID communityId = UUID.randomUUID();
+        normalChatRoom = new ChatRoom("COMMUNITY", communityId, "커뮤니티 채팅방", creatorId);
+    }
+
+    @Test
+    @DisplayName("택시 명령어 처리 - 매칭 채팅방에서 정상 동작")
+    void handleSlashCommand_TaxiCommandInMatchRoom_ProcessesSuccessfully() {
+        // Given
+        UUID roomId = matchChatRoom.getId();
+        UUID userId = UUID.randomUUID();
+        when(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(matchChatRoom));
+        
+        List<TaxiServiceResponse> mockResponses = List.of(
+                new TaxiServiceResponse("카카오T", 8000, 15),
+                new TaxiServiceResponse("우버", 7500, 12)
+        );
+        when(taxiComparisonService.compareService(any(UUID.class))).thenReturn(mockResponses);
+        when(taxiComparisonService.formatTaxiMessage(mockResponses)).thenReturn("택시 가격 비교 결과");
+
+        // When
+        chatMessageService.handleSlashCommand(userId, roomId, "/택시");
+
+        // Then
+        verify(chatRoomRepository).findById(roomId);
+        verify(taxiComparisonService).compareService(matchChatRoom.getSubjectId());
+        verify(taxiComparisonService).formatTaxiMessage(mockResponses);
+        verify(chatMessageRepository, atLeastOnce()).save(any(ChatMessage.class));
+    }
+
+    @Test
+    @DisplayName("택시 명령어 처리 - 일반 채팅방에서 차단")
+    void handleSlashCommand_TaxiCommandInNormalRoom_BlocksCommand() {
+        // Given
+        UUID roomId = normalChatRoom.getId();
+        UUID userId = UUID.randomUUID();
+        when(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(normalChatRoom));
+
+        // When
+        chatMessageService.handleSlashCommand(userId, roomId, "/택시");
+
+        // Then
+        verify(chatRoomRepository).findById(roomId);
+        verify(taxiComparisonService, never()).compareService(any(UUID.class));
+        verify(chatMessageRepository, atLeastOnce()).save(any(ChatMessage.class));
+    }
+
+    @Test
+    @DisplayName("택시 명령어 처리 - 채팅방 없음")
+    void handleSlashCommand_ChatRoomNotFound_HandlesGracefully() {
+        // Given
+        UUID roomId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        when(chatRoomRepository.findById(roomId)).thenReturn(Optional.empty());
+
+        // When
+        chatMessageService.handleSlashCommand(userId, roomId, "/택시");
+
+        // Then
+        verify(chatRoomRepository).findById(roomId);
+        verify(taxiComparisonService, never()).compareService(any(UUID.class));
+        verify(chatMessageRepository, atLeastOnce()).save(any(ChatMessage.class));
+    }
+
+    @Test
+    @DisplayName("택시 명령어 처리 - 서비스 에러")
+    void handleSlashCommand_ServiceError_HandlesGracefully() {
+        // Given
+        UUID roomId = matchChatRoom.getId();
+        UUID userId = UUID.randomUUID();
+        when(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(matchChatRoom));
+        when(taxiComparisonService.compareService(any(UUID.class)))
+                .thenThrow(new RuntimeException("서비스 에러"));
+
+        // When
+        chatMessageService.handleSlashCommand(userId, roomId, "/택시");
+
+        // Then
+        verify(chatRoomRepository).findById(roomId);
+        verify(taxiComparisonService).compareService(matchChatRoom.getSubjectId());
+        verify(chatMessageRepository, atLeastOnce()).save(any(ChatMessage.class));
+    }
+
+    @Test
+    @DisplayName("다양한 택시 명령어 인식 테스트")
+    void handleSlashCommand_VariousTaxiCommands_AllRecognized() {
+        // Given
+        UUID roomId = matchChatRoom.getId();
+        UUID userId = UUID.randomUUID();
+        when(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(matchChatRoom));
+        when(taxiComparisonService.compareService(any(UUID.class))).thenReturn(List.of());
+        when(taxiComparisonService.formatTaxiMessage(any())).thenReturn("택시 가격 비교 결과");
+
+        // When & Then
+        chatMessageService.handleSlashCommand(userId, roomId, "/택시");
+        chatMessageService.handleSlashCommand(userId, roomId, "/taxi");
+        chatMessageService.handleSlashCommand(userId, roomId, "/가격");
+        chatMessageService.handleSlashCommand(userId, roomId, "/요금");
+
+        // 모든 명령어가 택시 서비스를 호출하는지 확인
+        verify(taxiComparisonService, times(4)).compareService(any(UUID.class));
+    }
+
+    @Test
+    @DisplayName("도움말 명령어 처리 테스트")
+    void handleSlashCommand_HelpCommand_ProcessesSuccessfully() {
+        // Given
+        UUID roomId = matchChatRoom.getId();
+        UUID userId = UUID.randomUUID();
+
+        // When
+        chatMessageService.handleSlashCommand(userId, roomId, "/도움말");
+
+        // Then
+        verify(chatMessageRepository, atLeastOnce()).save(any(ChatMessage.class));
+    }
+
+    @Test
+    @DisplayName("알 수 없는 명령어 처리 테스트")
+    void handleSlashCommand_UnknownCommand_HandlesGracefully() {
+        // Given
+        UUID roomId = matchChatRoom.getId();
+        UUID userId = UUID.randomUUID();
+
+        // When
+        chatMessageService.handleSlashCommand(userId, roomId, "/알수없는명령어");
+
+        // Then
+        verify(chatMessageRepository, atLeastOnce()).save(any(ChatMessage.class));
+    }
+}

--- a/src/test/java/com/BeatUp/BackEnd/GeoUtilsTest.java
+++ b/src/test/java/com/BeatUp/BackEnd/GeoUtilsTest.java
@@ -1,0 +1,24 @@
+package com.BeatUp.BackEnd;
+
+import com.BeatUp.BackEnd.common.util.GeoUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GeoUtilsTest {
+
+    @Test
+    @DisplayName("거리 계산 - 같은 좌표")
+    void calculateDistance_SameCoordinates_ReturnsZero(){
+        // Given
+        double lat = 37.5665;
+        double lng = 126.9780;
+
+        // When
+        double distance = GeoUtils.calculateDistance(lat, lng, lat, lng);
+
+        // Then
+        assertEquals(0.0, distance, 0.001);
+    }
+}

--- a/src/test/java/com/BeatUp/BackEnd/Match/taxi/dto/response/TaxiServiceResponseTest.java
+++ b/src/test/java/com/BeatUp/BackEnd/Match/taxi/dto/response/TaxiServiceResponseTest.java
@@ -1,0 +1,221 @@
+package com.BeatUp.BackEnd.Match.taxi.dto.response;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+class TaxiServiceResponseTest {
+
+    @Test
+    @DisplayName("기본 생성자 테스트")
+    void constructor_Default_ReturnsEmptyObject() {
+        // When
+        TaxiServiceResponse response = new TaxiServiceResponse();
+
+        // Then
+        assertNull(response.getServiceName());
+        assertNull(response.getEstimatePrice());
+        assertNull(response.getEstimatedTime());
+        assertNull(response.getDeeplink());
+        assertNull(response.getWeblink());
+        assertNull(response.getDiscounts());
+    }
+
+    @Test
+    @DisplayName("필수 필드 생성자 테스트")
+    void constructor_RequiredFields_ReturnsCorrectObject() {
+        // Given
+        String serviceName = "카카오T";
+        Integer estimatePrice = 8000;
+        Integer estimatedTime = 15;
+
+        // When
+        TaxiServiceResponse response = new TaxiServiceResponse(serviceName, estimatePrice, estimatedTime);
+
+        // Then
+        assertEquals(serviceName, response.getServiceName());
+        assertEquals(estimatePrice, response.getEstimatePrice());
+        assertEquals(estimatedTime, response.getEstimatedTime());
+        assertNull(response.getDeeplink());
+        assertNull(response.getWeblink());
+        assertNull(response.getDiscounts());
+    }
+
+    @Test
+    @DisplayName("전체 필드 생성자 테스트")
+    void constructor_AllFields_ReturnsCorrectObject() {
+        // Given
+        String serviceName = "우버";
+        Integer estimatePrice = 7500;
+        Integer estimatedTime = 12;
+        String deeplink = "uber://ride";
+        String weblink = "https://uber.com";
+        List<String> discounts = List.of("첫 이용 할인", "주말 할인");
+
+        // When
+        TaxiServiceResponse response = new TaxiServiceResponse(
+                serviceName, estimatePrice, estimatedTime, deeplink, weblink, discounts
+        );
+
+        // Then
+        assertEquals(serviceName, response.getServiceName());
+        assertEquals(estimatePrice, response.getEstimatePrice());
+        assertEquals(estimatedTime, response.getEstimatedTime());
+        assertEquals(deeplink, response.getDeeplink());
+        assertEquals(weblink, response.getWeblink());
+        assertEquals(discounts, response.getDiscounts());
+    }
+
+    @Test
+    @DisplayName("Setter 테스트")
+    void setters_AllFields_UpdatesCorrectly() {
+        // Given
+        TaxiServiceResponse response = new TaxiServiceResponse();
+        String serviceName = "타다";
+        Integer estimatePrice = 9000;
+        Integer estimatedTime = 18;
+        String deeplink = "tada://ride";
+        String weblink = "https://tada.com";
+        List<String> discounts = List.of("신규 회원 할인");
+
+        // When
+        response.setServiceName(serviceName);
+        response.setEstimatePrice(estimatePrice);
+        response.setEstimatedTime(estimatedTime);
+        response.setDeeplink(deeplink);
+        response.setWeblink(weblink);
+        response.setDiscounts(discounts);
+
+        // Then
+        assertEquals(serviceName, response.getServiceName());
+        assertEquals(estimatePrice, response.getEstimatePrice());
+        assertEquals(estimatedTime, response.getEstimatedTime());
+        assertEquals(deeplink, response.getDeeplink());
+        assertEquals(weblink, response.getWeblink());
+        assertEquals(discounts, response.getDiscounts());
+    }
+
+    @Test
+    @DisplayName("카카오T 응답 생성 테스트")
+    void createKakaoTResponse_ReturnsCorrectValues() {
+        // Given
+        String serviceName = "카카오T";
+        Integer estimatePrice = 8000;
+        Integer estimatedTime = 15;
+
+        // When
+        TaxiServiceResponse response = new TaxiServiceResponse(serviceName, estimatePrice, estimatedTime);
+
+        // Then
+        assertEquals("카카오T", response.getServiceName());
+        assertEquals(8000, response.getEstimatePrice());
+        assertEquals(15, response.getEstimatedTime());
+    }
+
+    @Test
+    @DisplayName("우버 응답 생성 테스트")
+    void createUberResponse_ReturnsCorrectValues() {
+        // Given
+        String serviceName = "우버";
+        Integer estimatePrice = 7500;
+        Integer estimatedTime = 12;
+
+        // When
+        TaxiServiceResponse response = new TaxiServiceResponse(serviceName, estimatePrice, estimatedTime);
+
+        // Then
+        assertEquals("우버", response.getServiceName());
+        assertEquals(7500, response.getEstimatePrice());
+        assertEquals(12, response.getEstimatedTime());
+    }
+
+    @Test
+    @DisplayName("타다 응답 생성 테스트")
+    void createTadaResponse_ReturnsCorrectValues() {
+        // Given
+        String serviceName = "타다";
+        Integer estimatePrice = 9000;
+        Integer estimatedTime = 18;
+
+        // When
+        TaxiServiceResponse response = new TaxiServiceResponse(serviceName, estimatePrice, estimatedTime);
+
+        // Then
+        assertEquals("타다", response.getServiceName());
+        assertEquals(9000, response.getEstimatePrice());
+        assertEquals(18, response.getEstimatedTime());
+    }
+
+    @Test
+    @DisplayName("할인 정보가 있는 응답 테스트")
+    void createResponseWithDiscounts_ReturnsCorrectValues() {
+        // Given
+        String serviceName = "카카오T";
+        Integer estimatePrice = 8000;
+        Integer estimatedTime = 15;
+        String deeplink = "kakao://taxi";
+        String weblink = "https://taxi.kakao.com";
+        List<String> discounts = List.of("첫 이용 할인 20%", "주말 할인 10%");
+
+        // When
+        TaxiServiceResponse response = new TaxiServiceResponse(
+                serviceName, estimatePrice, estimatedTime, deeplink, weblink, discounts
+        );
+
+        // Then
+        assertEquals("카카오T", response.getServiceName());
+        assertEquals(8000, response.getEstimatePrice());
+        assertEquals(15, response.getEstimatedTime());
+        assertEquals("kakao://taxi", response.getDeeplink());
+        assertEquals("https://taxi.kakao.com", response.getWeblink());
+        assertEquals(2, response.getDiscounts().size());
+        assertTrue(response.getDiscounts().contains("첫 이용 할인 20%"));
+        assertTrue(response.getDiscounts().contains("주말 할인 10%"));
+    }
+
+    @Test
+    @DisplayName("null 값 처리 테스트")
+    void handleNullValues_WorksCorrectly() {
+        // Given
+        TaxiServiceResponse response = new TaxiServiceResponse();
+
+        // When
+        response.setServiceName(null);
+        response.setEstimatePrice(null);
+        response.setEstimatedTime(null);
+        response.setDeeplink(null);
+        response.setWeblink(null);
+        response.setDiscounts(null);
+
+        // Then
+        assertNull(response.getServiceName());
+        assertNull(response.getEstimatePrice());
+        assertNull(response.getEstimatedTime());
+        assertNull(response.getDeeplink());
+        assertNull(response.getWeblink());
+        assertNull(response.getDiscounts());
+    }
+
+    @Test
+    @DisplayName("빈 할인 리스트 테스트")
+    void createResponseWithEmptyDiscounts_ReturnsCorrectValues() {
+        // Given
+        String serviceName = "우버";
+        Integer estimatePrice = 7500;
+        Integer estimatedTime = 12;
+        List<String> emptyDiscounts = List.of();
+
+        // When
+        TaxiServiceResponse response = new TaxiServiceResponse(serviceName, estimatePrice, estimatedTime);
+        response.setDiscounts(emptyDiscounts);
+
+        // Then
+        assertEquals("우버", response.getServiceName());
+        assertEquals(7500, response.getEstimatePrice());
+        assertEquals(12, response.getEstimatedTime());
+        assertNotNull(response.getDiscounts());
+        assertTrue(response.getDiscounts().isEmpty());
+    }
+}

--- a/src/test/java/com/BeatUp/BackEnd/TaxiComparisonServiceTest.java
+++ b/src/test/java/com/BeatUp/BackEnd/TaxiComparisonServiceTest.java
@@ -1,0 +1,199 @@
+package com.BeatUp.BackEnd;
+
+
+import com.BeatUp.BackEnd.Concert.entity.Concert;
+import com.BeatUp.BackEnd.Concert.repository.ConcertRepository;
+import com.BeatUp.BackEnd.Match.entity.MatchGroup;
+import com.BeatUp.BackEnd.Match.repository.MatchGroupRepository;
+import com.BeatUp.BackEnd.Match.taxi.dto.response.TaxiServiceResponse;
+import com.BeatUp.BackEnd.Match.taxi.service.TaxiComparisonService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TaxiComparisonServiceTest {
+
+    @Mock
+    private MatchGroupRepository matchGroupRepository;
+
+    @Mock
+    private ConcertRepository concertRepository;
+
+    @InjectMocks
+    private TaxiComparisonService taxiComparisonService;
+
+    private MatchGroup matchGroup;
+    private Concert concert;
+
+    @BeforeEach
+    void setUp(){
+        // 매칭 그룹 설정
+        matchGroup = new MatchGroup();
+        matchGroup.setId(UUID.randomUUID());
+        matchGroup.setConcertId(UUID.randomUUID());
+        matchGroup.setDestBucket("37.5665, 126.9780"); // 서울 중심가
+
+        // 공연장 설정
+        concert = new Concert();
+        concert.setId(matchGroup.getConcertId());
+        concert.setVenue("올림픽공원");
+        concert.setVenueLat(37.5219);
+        concert.setVenueLng(127.1282);
+    }
+
+    @Test()
+    @DisplayName("택시 서비스 비교 - 정상 케이스")
+    void compareService_NormalCase_ReturnsAllServices(){
+        // Given
+        when(matchGroupRepository.findById(any(UUID.class))).thenReturn(Optional.of(matchGroup));
+        when(concertRepository.findById(any(UUID.class))).thenReturn(Optional.of(concert));
+
+        // When
+        List<TaxiServiceResponse> responses = taxiComparisonService.compareService(matchGroup.getId());
+
+        // Then
+        assertNotNull(responses);
+        assertEquals(3, responses.size()); // 카카오T, 우버, 타다
+
+        // 서비스명 확인
+        List<String> serviceNames = responses.stream()
+                .map(TaxiServiceResponse::getServiceName)
+                .toList();
+        assertTrue(serviceNames.contains("카카오T"));
+        assertTrue(serviceNames.contains("우버"));
+        assertTrue(serviceNames.contains("타다"));
+    }
+
+    @Test
+    @DisplayName("택시 서비스 비교 - 매칭 그룹 없음")
+    void compareService_MatchGroupNotFound_ThrowsException(){
+        // Given
+        when(matchGroupRepository.findById(any(UUID.class))).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(IllegalArgumentException.class, () -> {
+            taxiComparisonService.compareService(UUID.randomUUID());
+        });
+    }
+
+    @Test
+    @DisplayName("택시 서비스 비교 - 공연장 없음")
+    void compareService_ConcertNotFound_ThrowsException(){
+        // Given
+        when(matchGroupRepository.findById(any(UUID.class))).thenReturn(Optional.of(matchGroup));
+        when(concertRepository.findById(any(UUID.class))).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(IllegalArgumentException.class, () -> {
+            taxiComparisonService.compareService(matchGroup.getId());
+        });
+    }
+
+    @Test
+    @DisplayName("카카오T 요금 계산 - 기본 거리")
+    void getKakaoTPrice_ShortDistance_ReturnBaseFare(){
+        // Given
+        double pickupLat = 37.5665;
+        double pickupLng = 126.9780;
+        double destLat = 37.5700;
+        double destLng = 126.9800; // 약 1km 거리
+
+        // When
+        TaxiServiceResponse response = taxiComparisonService.getKakaoTPrice(pickupLat, pickupLng, destLat, destLng);
+
+        // Then
+        assertNotNull(response);
+        assertEquals("카카오T", response.getServiceName());
+        assertEquals(3900, response.getEstimatePrice()); // 기본요금 + 시간요금
+        assertTrue(response.getEstimatedTime() > 0);
+    }
+
+    @Test
+    @DisplayName("우버 요금 계산 - 장거리")
+    void getUberPrice_LongDistance_ReturnsCorrectFare() {
+        // Given
+        double pickupLat = 37.5665;
+        double pickupLng = 126.9780;
+        double destLat = 37.5000;
+        double destLng = 127.0000; // 약 10km 거리
+
+        // When
+        TaxiServiceResponse response = taxiComparisonService.getUberPrice(pickupLat, pickupLng, destLat, destLng);
+
+        // Then
+        assertNotNull(response);
+        assertEquals("우버", response.getServiceName());
+        assertTrue(response.getEstimatePrice() >= 3500); // 최소요금
+        assertTrue(response.getEstimatedTime() > 0);
+    }
+
+    @Test
+    @DisplayName("타다 요금 계산 - 기본 거리")
+    void getTadaPrice_ShortDistance_ReturnsBaseFare() {
+        // Given
+        double pickupLat = 37.5665;
+        double pickupLng = 126.9780;
+        double destLat = 37.5700;
+        double destLng = 126.9800; // 약 1km 거리
+
+        // When
+        TaxiServiceResponse response = taxiComparisonService.getTadaPrice(pickupLat, pickupLng, destLat, destLng);
+
+        // Then
+        assertNotNull(response);
+        assertEquals("타다", response.getServiceName());
+        assertEquals(5000, response.getEstimatePrice()); // 최소요금
+        assertTrue(response.getEstimatedTime() > 0);
+    }
+
+    @Test
+    @DisplayName("메시지 포맷팅 - 정상 케이스")
+    void formatTaxiMessage_NormalCase_ReturnsFormattedMessage() {
+        // Given
+        List<TaxiServiceResponse> options = new ArrayList<>();
+        options.add(new TaxiServiceResponse("카카오T", 8000, 15));
+        options.add(new TaxiServiceResponse("우버", 7500, 12));
+        options.add(new TaxiServiceResponse("타다", 9000, 18));
+
+        // When
+        String message = taxiComparisonService.formatTaxiMessage(options);
+
+        // Then
+        assertNotNull(message);
+        assertTrue(message.contains("택시 서비스 가격 비교"));
+        assertTrue(message.contains("카카오T"));
+        assertTrue(message.contains("우버"));
+        assertTrue(message.contains("타다"));
+        assertTrue(message.contains("8,000원"));
+        assertTrue(message.contains("7,500원"));
+        assertTrue(message.contains("9,000원"));
+    }
+
+    @Test
+    @DisplayName("메시지 포맷팅 - 빈 리스트")
+    void formatTaxiMessage_EmptyList_ReturnsErrorMessage() {
+        // Given
+        List<TaxiServiceResponse> options = List.of();
+
+        // When
+        String message = taxiComparisonService.formatTaxiMessage(options);
+
+        // Then
+        assertNotNull(message);
+        assertTrue(message.contains("택시 서비스 정보를 가져올 수 없습니다"));
+    }
+}


### PR DESCRIPTION
## 연관 이슈
> Closes #52 

## Description
> 매칭 성공 시 매칭된 목적지 정보를 기반으로 카카오 T, 우버, 타다  등 주요 택시/라이드 서비스의  예상 요금을 비교

### ✨ 구현 내용

#### 1. 택시 서비스 가격 비교 시스템
- **TaxiComparisonService**: 각 택시 서비스별 요금 계산 로직
  - 카카오T: 기본요금 3,800원, 거리/시간요금, 심야/거리할증 적용
  - 우버: UberX 기준, 수요할증 시스템 적용
  - 타다: 일반 서비스 기준, 시간대별 할증 적용

#### 2. 지리적 계산 유틸리티
- **GeoUtils**: Haversine 공식으로 정확한 거리 계산
- 평균 속도 30km/h 기준 예상 소요시간 계산

#### 3. 채팅 명령어 시스템
- **ChatMessageService**: `/택시`, `/taxi`, `/가격`, `/요금` 명령어 지원
- 매칭 채팅방에서만 사용 가능
- 실시간 가격 비교 결과를 채팅으로 표시

#### 4. 매칭 완료 시 자동 안내
- **MatchingScheduler**: 매칭 성공 시 택시 가격 비교 명령어 안내 메시지 자동 전송